### PR TITLE
refactor(user): Move GymmateUser Files

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/GymmateUserDetailsService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/GymmateUserDetailsService.java
@@ -1,4 +1,0 @@
-package org.helloworld.gymmate.domain.user.member.service;
-
-public class GymmateUserDetailsService {
-}

--- a/src/main/java/org/helloworld/gymmate/domain/user/model/GymmateUser.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/model/GymmateUser.java
@@ -1,4 +1,4 @@
-package org.helloworld.gymmate.domain.user.member.model;
+package org.helloworld.gymmate.domain.user.model;
 
 public class GymmateUser {
 	public String getNickname() {

--- a/src/main/java/org/helloworld/gymmate/domain/user/service/GymmateUserDetailsService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/service/GymmateUserDetailsService.java
@@ -1,0 +1,4 @@
+package org.helloworld.gymmate.domain.user.service;
+
+public class GymmateUserDetailsService {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/service/GymmateUserService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/service/GymmateUserService.java
@@ -1,8 +1,8 @@
-package org.helloworld.gymmate.domain.user.member.service;
+package org.helloworld.gymmate.domain.user.service;
 
 import java.util.Optional;
 
-import org.helloworld.gymmate.domain.user.member.model.GymmateUser;
+import org.helloworld.gymmate.domain.user.model.GymmateUser;
 import org.springframework.stereotype.Service;
 
 @Service

--- a/src/main/java/org/helloworld/gymmate/security/authentication/AuthGymmateUserProvider.java
+++ b/src/main/java/org/helloworld/gymmate/security/authentication/AuthGymmateUserProvider.java
@@ -2,7 +2,7 @@ package org.helloworld.gymmate.security.authentication;
 
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
-import org.helloworld.gymmate.domain.user.member.model.GymmateUser;
+import org.helloworld.gymmate.domain.user.model.GymmateUser;
 import org.springframework.stereotype.Component;
 
 @Component

--- a/src/main/java/org/helloworld/gymmate/security/authentication/GymmateUserDetails.java
+++ b/src/main/java/org/helloworld/gymmate/security/authentication/GymmateUserDetails.java
@@ -2,7 +2,7 @@ package org.helloworld.gymmate.security.authentication;
 
 import java.util.Collection;
 
-import org.helloworld.gymmate.domain.user.member.model.GymmateUser;
+import org.helloworld.gymmate.domain.user.model.GymmateUser;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.AuthorityUtils;
 import org.springframework.security.core.userdetails.UserDetails;

--- a/src/main/java/org/helloworld/gymmate/security/authentication/GymmateUserDetailsService.java
+++ b/src/main/java/org/helloworld/gymmate/security/authentication/GymmateUserDetailsService.java
@@ -1,6 +1,6 @@
 package org.helloworld.gymmate.security.authentication;
 
-import org.helloworld.gymmate.domain.user.member.service.GymmateUserService;
+import org.helloworld.gymmate.domain.user.service.GymmateUserService;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;

--- a/src/main/java/org/helloworld/gymmate/security/oauth2/LoginSuccessHandler.java
+++ b/src/main/java/org/helloworld/gymmate/security/oauth2/LoginSuccessHandler.java
@@ -5,7 +5,7 @@ import java.util.Optional;
 
 import org.helloworld.gymmate.common.cookie.CookieManager;
 import org.helloworld.gymmate.common.enums.TokenType;
-import org.helloworld.gymmate.domain.user.member.service.GymmateUserService;
+import org.helloworld.gymmate.domain.user.service.GymmateUserService;
 import org.helloworld.gymmate.security.policy.ExpirationPolicy;
 import org.helloworld.gymmate.security.token.JwtManager;
 import org.springframework.beans.factory.annotation.Value;


### PR DESCRIPTION
# 📝 GymmateUser 분리
refactor(user): GymmateUser (소셜 로그인용 모델) 위치 이동

---

## 🔘 Part
- user

---

## 🔎 작업 내용
- GymmateUser: 소셜 로그인용 모델
- Trainer: 트레이너 엔티티 (DB 테이블과 동일)
- Member: 일반회원 엔티티 (DB 테이블과 동일)

---

## 🖼️ 이미지 첨부

---

## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항

---

## 🔧 앞으로의 과제
- 소셜 로그인 연결

---

## ➕ 이슈 링크
- [GYMMATE-54](https://dia19.atlassian.net/browse/GYMMATE-54)

---


[GYMMATE-54]: https://dia19.atlassian.net/browse/GYMMATE-54?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ