### PR TITLE
feat(ptProduct) : ptProduct 삭제 및 연관 이미지 삭제

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/controller/PtProductController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/controller/PtProductController.java
@@ -9,6 +9,7 @@ import org.helloworld.gymmate.domain.pt.pt_product.dto.PtProductModifyRequest;
 import org.helloworld.gymmate.domain.pt.pt_product.service.PtProductService;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -47,6 +48,15 @@ public class PtProductController {
 
 		return ResponseEntity.ok(
 			Map.of("ptClassId",ptProductService.modifyPtProduct(productId, request, images)));
+	}
+
+	@DeleteMapping(value = "/{productId}")
+	public ResponseEntity<Map<String,Long>> deletePtProduct(
+		@PathVariable Long productId
+	){
+		// TODO : userDetail 넘겨줘야 함
+		ptProductService.deletePtProduct(productId);
+		return ResponseEntity.ok().build();
 	}
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/service/PtProductService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/service/PtProductService.java
@@ -54,6 +54,19 @@ public class PtProductService {
 		return productId;
 	}
 
+	@Transactional
+	public void deletePtProduct(Long productId) {
+		// TODO : 로그인한 id 받아와야 함
+		Long trainerId = 0L;
+
+		PtProduct ptProduct = findProductOrThrow(productId);
+		validateOwnership(ptProduct, trainerId);
+		ptProduct.getPtProductImages()
+			.forEach(image -> fileManager.deleteFile(image.getUrl()));
+
+		ptProductRepository.delete(ptProduct);
+	}
+
 	private void saveProductImages(PtProduct ptProduct, List<MultipartFile> images) {
 		List<String> imageUrls = fileManager.uploadFiles(images, "ptProduct");
 		List<PtProductImage> ptProductImages = imageUrls.stream()
@@ -81,5 +94,4 @@ public class PtProductService {
 				fileManager.deleteFile(url);
 			}));
 	}
-
 }


### PR DESCRIPTION
# feat(도메인): delete ptProduct & relational images

---

## 🔘 Part
- pt
 - ptProduct

---

## 🔎 작업 내용
- ptProduct, ptProductImage 관련 전부삭제
- s3에서도 삭제

---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [ ] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
