### PR TITLE
feat(myself): Implement RecordController & CreateRecord

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/controller/RecordController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/controller/RecordController.java
@@ -23,11 +23,11 @@ public class RecordController {
 
     @PostMapping
     public ResponseEntity<Map<String, Long>> createRecord(
-            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //TODO: Oauth2User로 변경
             @RequestBody RecordCreateRequest request) {
 
         long recordId = 0;
-        Member member = null; //Oauth2User.getMember
+        Member member = null; //TODO: Oauth2User.getMember
         recordService.createRecord(request, member);
 
         return ResponseEntity.ok(
@@ -36,10 +36,10 @@ public class RecordController {
 
     @DeleteMapping(value = "/{recordId}")
     public ResponseEntity<Map<String, Long>> deleteRecord(
-            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //TODO: Oauth2User로 변경
             @PathVariable Long recordId) {
 
-        Member member = null; //Oauth2User.getMember
+        Member member = null; //TODO: Oauth2User.getMember
         recordService.deleteRecord(recordId, member);
 
         return ResponseEntity.ok().build();
@@ -47,11 +47,11 @@ public class RecordController {
 
     @PutMapping(value = "/{recordId}")
     public ResponseEntity<Map<String, Long>> modifyRecord(
-            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //TODO: Oauth2User로 변경
             @PathVariable Long recordId,
             @RequestBody RecordModifyRequest request) {
 
-        Member member = null; //Oauth2User.getMember
+        Member member = null; //TODO: Oauth2User.getMember
         recordService.modifyRecord(recordId, request, member);
 
         return ResponseEntity.ok().build();
@@ -59,11 +59,11 @@ public class RecordController {
 
     @GetMapping
     public ResponseEntity<PageDto<RecordResponse>> getRecords(
-            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //TODO: Oauth2User로 변경
             @RequestParam int page,
             @RequestParam int size) {
 
-        Member member = null; //Oauth2User.getMember
+        Member member = null; //TODO: Oauth2User.getMember
 
         return ResponseEntity.ok(PageMapper.toPageDto(
                 recordService.getRecords(page, size, member)));

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/controller/RecordController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/controller/RecordController.java
@@ -7,6 +7,7 @@ import org.helloworld.gymmate.domain.myself.record.dto.RecordCreateRequest;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordModifyRequest;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordResponse;
 import org.helloworld.gymmate.domain.myself.record.service.RecordService;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.security.model.GymmateUserDetails;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -26,7 +27,8 @@ public class RecordController {
             @RequestBody RecordCreateRequest request) {
 
         long recordId = 0;
-        recordService.createRecord(request, userDetails.getGymmateUser()); //Oauth2User로 변경 예정
+        Member member = null; //Oauth2User.getMember
+        recordService.createRecord(request, member);
 
         return ResponseEntity.ok(
                 Map.of("recordId", recordId));
@@ -37,7 +39,8 @@ public class RecordController {
             @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
             @PathVariable Long recordId) {
 
-        recordService.deleteRecord(recordId, userDetails.getGymmateUser()); //Oauth2User로 변경 예정
+        Member member = null; //Oauth2User.getMember
+        recordService.deleteRecord(recordId, member);
 
         return ResponseEntity.ok().build();
     }
@@ -48,7 +51,8 @@ public class RecordController {
             @PathVariable Long recordId,
             @RequestBody RecordModifyRequest request) {
 
-        recordService.modifyRecord(recordId, request, userDetails.getGymmateUser()); //Oauth2User로 변경 예정
+        Member member = null; //Oauth2User.getMember
+        recordService.modifyRecord(recordId, request, member);
 
         return ResponseEntity.ok().build();
     }
@@ -59,7 +63,9 @@ public class RecordController {
             @RequestParam int page,
             @RequestParam int size) {
 
+        Member member = null; //Oauth2User.getMember
+
         return ResponseEntity.ok(PageMapper.toPageDto(
-                recordService.getRecords(page, size, userDetails)));
+                recordService.getRecords(page, size, member)));
     }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/controller/RecordController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/controller/RecordController.java
@@ -1,0 +1,65 @@
+package org.helloworld.gymmate.domain.myself.record.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.helloworld.gymmate.common.dto.PageDto;
+import org.helloworld.gymmate.common.mapper.PageMapper;
+import org.helloworld.gymmate.domain.myself.record.dto.RecordCreateRequest;
+import org.helloworld.gymmate.domain.myself.record.dto.RecordModifyRequest;
+import org.helloworld.gymmate.domain.myself.record.dto.RecordResponse;
+import org.helloworld.gymmate.domain.myself.record.service.RecordService;
+import org.helloworld.gymmate.security.model.GymmateUserDetails;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/record")
+@RequiredArgsConstructor
+public class RecordController {
+    private final RecordService recordService;
+
+    @PostMapping
+    public ResponseEntity<Map<String, Long>> createRecord(
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @RequestBody RecordCreateRequest request) {
+
+        long recordId = 0;
+        recordService.createRecord(request, userDetails.getGymmateUser()); //Oauth2User로 변경 예정
+
+        return ResponseEntity.ok(
+                Map.of("recordId", recordId));
+    }
+
+    @DeleteMapping(value = "/{recordId}")
+    public ResponseEntity<Map<String, Long>> deleteRecord(
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @PathVariable Long recordId) {
+
+        recordService.deleteRecord(recordId, userDetails.getGymmateUser()); //Oauth2User로 변경 예정
+
+        return ResponseEntity.ok().build();
+    }
+
+    @PutMapping(value = "/{recordId}")
+    public ResponseEntity<Map<String, Long>> modifyRecord(
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @PathVariable Long recordId,
+            @RequestBody RecordModifyRequest request) {
+
+        recordService.modifyRecord(recordId, request, userDetails.getGymmateUser()); //Oauth2User로 변경 예정
+
+        return ResponseEntity.ok().build();
+    }
+
+    @GetMapping
+    public ResponseEntity<PageDto<RecordResponse>> getRecords(
+            @AuthenticationPrincipal GymmateUserDetails userDetails, //Oauth2User로 변경 예정
+            @RequestParam int page,
+            @RequestParam int size) {
+
+        return ResponseEntity.ok(PageMapper.toPageDto(
+                recordService.getRecords(page, size, userDetails)));
+    }
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordCreateRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordCreateRequest.java
@@ -1,13 +1,11 @@
 package org.helloworld.gymmate.domain.myself.record.dto;
 
 import jakarta.validation.constraints.NotBlank;
-import jakarta.validation.constraints.NotNull;
 
 import java.time.LocalDate;
 
 public record RecordCreateRequest(
-        @NotNull(message = "날짜를 입력해주세요.")
-        LocalDate date,
+        LocalDate date, // 생략 가능
         @NotBlank(message = "제목을 입력해주세요.")
         String title,
         @NotBlank(message = "내용을 입력해주세요.")

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordCreateRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordCreateRequest.java
@@ -1,0 +1,17 @@
+package org.helloworld.gymmate.domain.myself.record.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+
+import java.time.LocalDate;
+
+public record RecordCreateRequest(
+        @NotNull(message = "날짜를 입력해주세요.")
+        LocalDate date,
+        @NotBlank(message = "제목을 입력해주세요.")
+        String title,
+        @NotBlank(message = "내용을 입력해주세요.")
+        String content
+) {
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordModifyRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordModifyRequest.java
@@ -1,0 +1,12 @@
+package org.helloworld.gymmate.domain.myself.record.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+public record RecordModifyRequest(
+        @NotBlank(message = "제목을 입력해주세요.")
+        String title,
+        @NotBlank(message = "내용을 입력해주세요.")
+        String content
+) {
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/dto/RecordResponse.java
@@ -1,0 +1,12 @@
+package org.helloworld.gymmate.domain.myself.record.dto;
+
+import java.time.LocalDate;
+
+public record RecordResponse(
+        Long recordId,
+        LocalDate date,
+        String title,
+        String content
+) {
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/entity/Record.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/entity/Record.java
@@ -1,0 +1,34 @@
+package org.helloworld.gymmate.domain.myself.record.entity;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
+
+import java.time.LocalDate;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "record")
+public class Record {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "record_id")
+    private Long recordId;
+
+    @Column(name = "date")
+    private LocalDate date;
+
+    @Column(name = "title")
+    private String title;
+
+    @Column(name = "content")
+    private String content;
+
+    @Setter
+    @ManyToOne
+    @JoinColumn(name = "member_id")
+    private Member member;
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/repository/RecordRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/repository/RecordRepository.java
@@ -1,5 +1,6 @@
 package org.helloworld.gymmate.domain.myself.record.repository;
 
+import org.helloworld.gymmate.domain.myself.record.entity.Record;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/repository/RecordRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/repository/RecordRepository.java
@@ -1,0 +1,8 @@
+package org.helloworld.gymmate.domain.myself.record.repository;
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface RecordRepository extends JpaRepository<Record, Long> {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/service/RecordService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/service/RecordService.java
@@ -1,16 +1,34 @@
 package org.helloworld.gymmate.domain.myself.record.service;
 
+import lombok.RequiredArgsConstructor;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordCreateRequest;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordModifyRequest;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordResponse;
+import org.helloworld.gymmate.domain.myself.record.entity.Record;
+import org.helloworld.gymmate.domain.myself.record.repository.RecordRepository;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
+import java.time.LocalDate;
+
 @Service
+@RequiredArgsConstructor
 public class RecordService {
+    private final RecordRepository recordRepository;
 
     public void createRecord(RecordCreateRequest request, Member member) {
+        // 날짜가 비어있으면 현재 시간 넣기
+        LocalDate date = request.date() != null ? request.date() : LocalDate.now();
+
+        Record record = Record.builder()
+                .date(date)
+                .title(request.title())
+                .content(request.content())
+                .member(member)
+                .build();
+
+        recordRepository.save(record);
     }
 
     public void deleteRecord(Long recordId, Member member) {

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/service/RecordService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/service/RecordService.java
@@ -3,24 +3,23 @@ package org.helloworld.gymmate.domain.myself.record.service;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordCreateRequest;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordModifyRequest;
 import org.helloworld.gymmate.domain.myself.record.dto.RecordResponse;
-import org.helloworld.gymmate.security.model.GymmateUser;
-import org.helloworld.gymmate.security.model.GymmateUserDetails;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.springframework.data.domain.Page;
 import org.springframework.stereotype.Service;
 
 @Service
 public class RecordService {
 
-    public void createRecord(RecordCreateRequest request, GymmateUser gymmateUser) {
+    public void createRecord(RecordCreateRequest request, Member member) {
     }
 
-    public void deleteRecord(Long recordId, GymmateUser gymmateUser) {
+    public void deleteRecord(Long recordId, Member member) {
     }
 
-    public void modifyRecord(Long recordId, RecordModifyRequest request, GymmateUser gymmateUser) {
+    public void modifyRecord(Long recordId, RecordModifyRequest request, Member member) {
     }
 
-    public Page<RecordResponse> getRecords(int page, int size, GymmateUserDetails userDetails) {
+    public Page<RecordResponse> getRecords(int page, int size, Member member) {
         return null;
     }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/record/service/RecordService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/record/service/RecordService.java
@@ -1,0 +1,26 @@
+package org.helloworld.gymmate.domain.myself.record.service;
+
+import org.helloworld.gymmate.domain.myself.record.dto.RecordCreateRequest;
+import org.helloworld.gymmate.domain.myself.record.dto.RecordModifyRequest;
+import org.helloworld.gymmate.domain.myself.record.dto.RecordResponse;
+import org.helloworld.gymmate.security.model.GymmateUser;
+import org.helloworld.gymmate.security.model.GymmateUserDetails;
+import org.springframework.data.domain.Page;
+import org.springframework.stereotype.Service;
+
+@Service
+public class RecordService {
+
+    public void createRecord(RecordCreateRequest request, GymmateUser gymmateUser) {
+    }
+
+    public void deleteRecord(Long recordId, GymmateUser gymmateUser) {
+    }
+
+    public void modifyRecord(Long recordId, RecordModifyRequest request, GymmateUser gymmateUser) {
+    }
+
+    public Page<RecordResponse> getRecords(int page, int size, GymmateUserDetails userDetails) {
+        return null;
+    }
+}


### PR DESCRIPTION
# 📝 RecordController & 운동 일지 생성 구현

---

## 🔘 Part
- myself
  - 운동 일지

---

## 🔎 작업 내용
- RecordController 구현
  로그인 부분 구현 완료 후 인증된 member 가져오는 로직 수정 필요
- 운동 일지 생성 구현
  RecordService의 createRecord 구현

---

## 🖼️ 이미지 첨부

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- .

---

## 🔧 앞으로의 과제
- deleteRecord, modifyRecord, getRecords 구현
- mapper 분리
- 예외처리 로직 추가

---

## ➕ 이슈 링크
- [GYMMATE-147](https://dia19.atlassian.net/browse/GYMMATE-147)

---


[GYMMATE-147]: https://dia19.atlassian.net/browse/GYMMATE-147?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ