### PR TITLE
feat(member): 회원가입 후 추가정보 등록

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
@@ -1,4 +1,66 @@
 package org.helloworld.gymmate.domain.user.member.controller;
 
+import java.util.Map;
+
+import org.helloworld.gymmate.domain.user.member.dto.MemberRequest;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.helloworld.gymmate.domain.user.member.service.MemberService;
+import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@RestController
+@RequiredArgsConstructor
 public class MemberController {
+
+	private final MemberService memberService;
+
+	/**
+	 * 회원 추가 정보 등록
+	 */
+	@PostMapping("/member/register")
+	public ResponseEntity<Map<String, Long>> registerAdditionalInfo(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
+		@Valid @RequestBody MemberRequest request
+	) {
+		log.info("회원 추가 정보 등록 요청: userId={}", oAuth2User.getUserId());
+
+		Member member = memberService.findByUserId(oAuth2User.getUserId());
+		Long memberId = memberService.registerInfoMember(member, request);
+
+		return ResponseEntity.ok(Map.of("memberId", memberId));
+	}
+
+	/**
+	 * 회원 추가 정보 등록 여부 확인
+	 */
+	@GetMapping("/check-info")
+	public ResponseEntity<Map<String, Boolean>> checkAdditionalInfo(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User
+	) {
+		Member member = memberService.findByUserId(oAuth2User.getUserId());
+		boolean isCompleted = memberService.check(member);
+
+		return ResponseEntity.ok(Map.of("isCompleted", isCompleted));
+	}
+
+	/**
+	 * 회원 정보 조회
+	 */
+	@GetMapping("/me")
+	public ResponseEntity<Map<String, Member>> getMyInfo(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User
+	) {
+		Member member = memberService.findByUserId(oAuth2User.getUserId());
+		return ResponseEntity.ok(Map.of("member", member));
+	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
@@ -28,29 +28,16 @@ public class MemberController {
 	 * 회원 추가 정보 등록
 	 */
 	@PostMapping("/member/register")
-	public ResponseEntity<Map<String, Long>> registerAdditionalInfo(
+	public ResponseEntity<Long> registerAdditionalInfo(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
 		@Valid @RequestBody MemberRequest request
 	) {
-		log.info("회원 추가 정보 등록 요청: userId={}", oAuth2User.getUserId());
+		log.debug("회원 추가 정보 등록 요청: userId={}", oAuth2User.getUserId());
 
 		Member member = memberService.findByUserId(oAuth2User.getUserId());
 		Long memberId = memberService.registerInfoMember(member, request);
 
-		return ResponseEntity.ok(Map.of("memberId", memberId));
-	}
-
-	/**
-	 * 회원 추가 정보 등록 여부 확인
-	 */
-	@GetMapping("/check-info")
-	public ResponseEntity<Map<String, Boolean>> checkAdditionalInfo(
-		@AuthenticationPrincipal CustomOAuth2User oAuth2User
-	) {
-		Member member = memberService.findByUserId(oAuth2User.getUserId());
-		boolean isCompleted = memberService.check(member);
-
-		return ResponseEntity.ok(Map.of("isCompleted", isCompleted));
+		return ResponseEntity.ok(memberId);
 	}
 
 	/**

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
@@ -1,9 +1,9 @@
 package org.helloworld.gymmate.domain.user.member.controller;
 
-import java.util.Map;
-
 import org.helloworld.gymmate.domain.user.member.dto.MemberRequest;
+import org.helloworld.gymmate.domain.user.member.dto.MemberResponse;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.helloworld.gymmate.domain.user.member.mapper.MemberMapper;
 import org.helloworld.gymmate.domain.user.member.service.MemberService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
@@ -44,10 +44,12 @@ public class MemberController {
 	 * 회원 정보 조회
 	 */
 	@GetMapping("/me")
-	public ResponseEntity<Map<String, Member>> getMyInfo(
+	public ResponseEntity<MemberResponse> getMyInfo(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User
 	) {
 		Member member = memberService.findByUserId(oAuth2User.getUserId());
-		return ResponseEntity.ok(Map.of("member", member));
+		MemberResponse memberResponse = MemberMapper.toResponseDto(member);
+		
+		return ResponseEntity.ok(memberResponse);
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/dto/MemberRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/dto/MemberRequest.java
@@ -1,7 +1,5 @@
 package org.helloworld.gymmate.domain.user.member.dto;
 
-import org.helloworld.gymmate.domain.user.enums.GenderType;
-
 import jakarta.validation.constraints.NotNull;
 
 public record MemberRequest(
@@ -19,8 +17,7 @@ public record MemberRequest(
 	String birthday,
 
 	@NotNull(message = "성별은 필수입니다.")
-	GenderType gender,
-
+	String gender,
 	//신체정보
 	String height,
 

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/dto/MemberResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/dto/MemberResponse.java
@@ -1,0 +1,41 @@
+package org.helloworld.gymmate.domain.user.member.dto;
+
+public record MemberResponse(
+
+	String phoneNumber,
+
+	String memberName,
+
+	String email,
+
+	String birthday,
+
+	String gender,
+	//신체정보
+	String height,
+
+	String weight,
+
+	//주소
+	String address,
+
+	String xField,
+
+	String yField,
+
+	//3대
+	Double recentBench,
+
+	Double recentDeadlift,
+
+	Double recentSquat,
+
+	Integer level,
+
+	//계정잠김
+	Boolean isAccountNonLocked,
+
+	Long cash
+
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
@@ -78,6 +78,9 @@ public class Member {
 	@Column(name = "recent_squat")
 	private Double recentSquat;
 
+	@Column(name = "level")
+	private Integer level;
+
 	//계정잠김여부
 	@Column(name = "is_account_nonloked")
 	private Boolean isAccountNonLocked;

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
@@ -48,8 +48,8 @@ public class Member {
 	private String birthday;
 
 	@Enumerated(value = EnumType.STRING)
-	@Column(name = "gender", nullable = false)
-	private GenderType gender;
+	@Column(name = "genderType", nullable = false)
+	private GenderType genderType;
 
 	//신체정보
 	@Column(name = "height")
@@ -97,7 +97,7 @@ public class Member {
 		this.memberName = request.memberName();
 		this.email = request.email();
 		this.birthday = request.birthday();
-		this.gender = request.gender();
+		this.genderType = GenderType.fromString(request.gender());
 		this.height = request.height();
 		this.weight = request.weight();
 		this.address = request.address();

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/mapper/MemberMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/mapper/MemberMapper.java
@@ -1,6 +1,7 @@
 package org.helloworld.gymmate.domain.user.member.mapper;
 
 import org.helloworld.gymmate.domain.user.enums.GenderType;
+import org.helloworld.gymmate.domain.user.member.dto.MemberResponse;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
 
@@ -18,4 +19,24 @@ public class MemberMapper {
 			.build();
 	}
 
+	public static MemberResponse toResponseDto(Member member) {
+		return new MemberResponse(
+			member.getPhoneNumber(),
+			member.getMemberName(),
+			member.getEmail(),
+			member.getBirthday(),
+			member.getGenderType().toString(),
+			member.getHeight(),
+			member.getWeight(),
+			member.getAddress(),
+			member.getXField(),
+			member.getYField(),
+			member.getRecentBench(),
+			member.getRecentDeadlift(),
+			member.getRecentSquat(),
+			member.getLevel(),
+			member.getIsAccountNonLocked(),
+			member.getCash()
+		);
+	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/mapper/MemberMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/mapper/MemberMapper.java
@@ -12,7 +12,7 @@ public class MemberMapper {
 			.phoneNumber("010-1111-2222")
 			.memberName("이름1")
 			.email("aa@naver.com")
-			.gender(GenderType.FEMALE)
+			.genderType(GenderType.FEMALE)
 			.birthday("2000-00-00")
 			.additionalInfoCompleted(false)
 			.build();

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
@@ -12,4 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByOauth(Oauth oauth);
 
 	Optional<Member> findByMemberId(Long memberId);
+
+	void deleteByMemberId(Long memberId);
+
+	boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
@@ -12,8 +12,4 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByOauth(Oauth oauth);
 
 	Optional<Member> findByMemberId(Long memberId);
-
-	void deleteByMemberId(Long memberId);
-
-	boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
@@ -37,9 +37,10 @@ public class MemberService {
 
 	//추가정보 등록
 	@Transactional
-	public void registerInfoMember(Member member, MemberRequest request) {
+	public Long registerInfoMember(Member member, MemberRequest request) {
 		member.registerMemberInfo(request);
-		memberRepository.save(member);
+		Member savedMember = memberRepository.save(member);
+		return savedMember.getMemberId();
 	}
 
 	//추가정보 등록 여부 확인

--- a/src/main/java/org/helloworld/gymmate/security/oauth/service/CustomOAuth2UserService.java
+++ b/src/main/java/org/helloworld/gymmate/security/oauth/service/CustomOAuth2UserService.java
@@ -7,6 +7,7 @@ import java.util.Map;
 
 import org.helloworld.gymmate.common.rq.Rq;
 import org.helloworld.gymmate.domain.user.enums.UserType;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.domain.user.member.service.MemberService;
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.domain.user.trainer.service.TrainerService;
@@ -88,7 +89,17 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 		//  권한 부여 (ROLE_MEMBER 또는 ROLE_TRAINER)
 		Collection<GrantedAuthority> authorities = List.of(new SimpleGrantedAuthority("ROLE_" + userTypeStr));
 
-		Trainer trainer = trainerService.findByUserId(userId);
+		// 사용자 타입에 따라 다른 서비스 호출
+		String userName;
+		if (userType == UserType.MEMBER) {
+			Member member = memberService.findByUserId(userId);
+			userName = member.getMemberName();
+		} else {
+			Trainer trainer = trainerService.findByUserId(userId);
+			userName = trainer.getTrainerName();
+		}
+
+		final String finalUserName = userName;
 
 		OAuth2User dummyOAuth2User = new OAuth2User() {
 			@Override
@@ -103,7 +114,7 @@ public class CustomOAuth2UserService extends DefaultOAuth2UserService {
 
 			@Override
 			public String getName() {
-				return trainer.getTrainerName();
+				return finalUserName;
 			}
 		};
 


### PR DESCRIPTION


## 🔘 Part
- member 회원가입

---

## 🔎 작업 내용
- 회원가입 후 추가정보 등록
- CustomOauth2Service 클래스의 laodUserByUserId에 member용 코드 추가
- member 컨트롤러 : member 추가정보 등록, 추가정보등록여부 확인 , 조회
- memberRequest DTO에서 gender 필드를 String 타입으로 변경 (entity에서는 GenderType사용)
---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료
- main을 merge 후 실행 문제 발생
---

## 🙏 리뷰 요청 사항

---

## 🔧 앞으로의 과제
- 멤버 수정, 삭제, 조회

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
