### PR TITLE
feat(member) : member 삭제 로직

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
@@ -8,6 +8,7 @@ import org.helloworld.gymmate.domain.user.member.service.MemberService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -24,9 +25,7 @@ public class MemberController {
 
 	private final MemberService memberService;
 
-	/**
-	 * 회원 추가 정보 등록
-	 */
+	//회원 추가정보 등록
 	@PostMapping("/member/register")
 	public ResponseEntity<Long> registerAdditionalInfo(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User,
@@ -40,16 +39,28 @@ public class MemberController {
 		return ResponseEntity.ok(memberId);
 	}
 
-	/**
-	 * 회원 정보 조회
-	 */
-	@GetMapping("/me")
+	//회원 정보 조회
+	@GetMapping("/member/me")
 	public ResponseEntity<MemberResponse> getMyInfo(
 		@AuthenticationPrincipal CustomOAuth2User oAuth2User
 	) {
 		Member member = memberService.findByUserId(oAuth2User.getUserId());
 		MemberResponse memberResponse = MemberMapper.toResponseDto(member);
-		
+
 		return ResponseEntity.ok(memberResponse);
+	}
+
+	//회원 삭제
+	@DeleteMapping("/member")
+	public ResponseEntity<Void> deleteMember(
+		@AuthenticationPrincipal CustomOAuth2User oAuth2User
+	) {
+		log.debug("회원 탈퇴 요청: userId={}", oAuth2User.getUserId());
+
+		memberService.deleteMember(oAuth2User.getUserId());
+
+		log.info("회원 탈퇴 완료: userId={}", oAuth2User.getUserId());
+
+		return ResponseEntity.ok().build();
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/controller/MemberController.java
@@ -59,7 +59,7 @@ public class MemberController {
 
 		memberService.deleteMember(oAuth2User.getUserId());
 
-		log.info("회원 탈퇴 완료: userId={}", oAuth2User.getUserId());
+		log.debug("회원 탈퇴 완료: userId={}", oAuth2User.getUserId());
 
 		return ResponseEntity.ok().build();
 	}

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
@@ -12,4 +12,8 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
 	Optional<Member> findByOauth(Oauth oauth);
 
 	Optional<Member> findByMemberId(Long memberId);
+
+	void deleteByMemberId(Long memberId);
+
+	boolean existsByMemberId(Long memberId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
@@ -85,7 +85,7 @@ public class MemberService {
 		}
 
 		memberRepository.deleteByMemberId(memberId);
-		log.info("회원이 성공적으로 삭제되었습니다. memberId={}", memberId);
+		log.debug("회원이 성공적으로 삭제되었습니다. memberId={}", memberId);
 
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
@@ -66,7 +66,6 @@ public class MemberService {
 			ErrorCode.USER_NOT_FOUND));
 	}
 
-	//
 	// @Transactional
 	// public void deleteMember(Long memberId) {
 	//
@@ -76,14 +75,16 @@ public class MemberService {
 	// 		throw new BusinessException(ErrorCode.USER_NOT_FOUND);
 	// 	}
 	// }
+
 	@Transactional
 	public void deleteMember(Long memberId) {
 		log.debug("회원 삭제 시작: memberId={}", memberId);
 
-		Member member = memberRepository.findByMemberId(memberId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+		Member member = this.findByUserId(memberId);
 
-		// OAuth ID 가져오기
+		//TODO: trainer와의 외래키 제약조건 해결 시 아래 Oauth 관련 코드 삭제
+
+		//OAuth ID 가져오기
 		Oauth oauth = member.getOauth();
 
 		// Trainer 테이블에서 해당 OAuth 관련 데이터가 있는지 확인 및 처리

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
@@ -66,16 +66,6 @@ public class MemberService {
 			ErrorCode.USER_NOT_FOUND));
 	}
 
-	// @Transactional
-	// public void deleteMember(Long memberId) {
-	//
-	// 	if (memberRepository.existsByMemberId(memberId)) { // 멤버가 존재하는지 확인
-	// 		memberRepository.deleteByMemberId(memberId);  // 멤버 삭제
-	// 	} else {
-	// 		throw new BusinessException(ErrorCode.USER_NOT_FOUND);
-	// 	}
-	// }
-
 	@Transactional
 	public void deleteMember(Long memberId) {
 		log.debug("회원 삭제 시작: memberId={}", memberId);


### PR DESCRIPTION
# 📝 member 삭제 로직 ( 컨트롤러, 서비스, 레포지토리)


## 🔎 작업 내용
- 멤버 삭제 시 , oauth는 cascade = CascadeType.ALL, orphanRemoval = true로 인해 삭제됨.
- 외래 키 제약조건 때문에 바로 삭제가 안되므로, Trainer 테이블에서 해당 OAuth 관련 데이터가 있는지 확인 및 처리 후 삭제됨...



## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료


