### PR TITLE
feat(trainer) : 트레이너 마이페이지 조회, 사장 여부 체크 구현

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/controller/TrainerController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/controller/TrainerController.java
@@ -1,15 +1,18 @@
 package org.helloworld.gymmate.domain.user.trainer.controller;
 
 import org.helloworld.gymmate.domain.user.trainer.dto.OwnerRegisterRequest;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerCheckResponse;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerModifyRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerProfileRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerRegisterRequest;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerResponse;
 import org.helloworld.gymmate.domain.user.trainer.service.TrainerService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -71,6 +74,21 @@ public class TrainerController {
 		return ResponseEntity.ok()
 			.body(trainerService.updateTrainerProfile(trainerService.findByUserId(customOAuth2User.getUserId()),
 				profileRequest));
+	}
+
+	// 마이페이지 정보
+	@GetMapping
+	public ResponseEntity<TrainerResponse> getInfo(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+		return ResponseEntity.ok()
+			.body(trainerService.getInfo(trainerService.findByUserId(customOAuth2User.getUserId())));
+	}
+
+	// 트레이너인지 check -> 메인페이지 활용
+	@GetMapping("/check")
+	public ResponseEntity<TrainerCheckResponse> check(@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+		return ResponseEntity.ok()
+			.body(trainerService.check(trainerService.findByUserId(customOAuth2User.getUserId())));
+
 	}
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerCheckResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerCheckResponse.java
@@ -1,0 +1,7 @@
+package org.helloworld.gymmate.domain.user.trainer.dto;
+
+public record TrainerCheckResponse(
+	String userType,
+	Boolean isOwner
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerResponse.java
@@ -2,6 +2,15 @@ package org.helloworld.gymmate.domain.user.trainer.dto;
 
 public record TrainerResponse(
 	Long trainerId,
-	String trainerName
+	String trainerName,
+	String bank,
+	String account,
+	String gender,
+	String profile,
+	Boolean isOwner,
+	Long cash,
+	String intro,
+	String career,
+	String field
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/mapper/TrainerMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/mapper/TrainerMapper.java
@@ -1,5 +1,8 @@
 package org.helloworld.gymmate.domain.user.trainer.mapper;
 
+import org.helloworld.gymmate.domain.user.enums.UserType;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerCheckResponse;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerResponse;
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
 
@@ -14,6 +17,27 @@ public class TrainerMapper {
 			.cash(100000000L)
 			.additionalInfoCompleted(false)
 			.build();
+	}
+
+	public static TrainerResponse toResponse(Trainer trainer) {
+		return new TrainerResponse(trainer.getTrainerId(),
+			trainer.getTrainerName(),
+			trainer.getBank(),
+			trainer.getAccount(),
+			trainer.getGenderType().toString(),
+			trainer.getProfile(),
+			trainer.getIsOwner(),
+			trainer.getCash(),
+			trainer.getIntro(),
+			trainer.getCareer(),
+			trainer.getField());
+	}
+
+	public static TrainerCheckResponse toCheckResponse(Trainer trainer) {
+		return new TrainerCheckResponse(
+			UserType.TRAINER.toString(),
+			trainer.getIsOwner()
+		);
 	}
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
@@ -9,9 +9,11 @@ import org.helloworld.gymmate.domain.gym.gym.repository.GymRepository;
 import org.helloworld.gymmate.domain.user.enums.UserType;
 import org.helloworld.gymmate.domain.user.trainer.business.service.BusinessValidateService;
 import org.helloworld.gymmate.domain.user.trainer.dto.OwnerRegisterRequest;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerCheckResponse;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerModifyRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerProfileRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerRegisterRequest;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerResponse;
 import org.helloworld.gymmate.domain.user.trainer.mapper.TrainerMapper;
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
@@ -78,6 +80,18 @@ public class TrainerService {
 	@Transactional
 	public void deleteTrainer(Trainer trainer) {
 		trainerRepository.delete(trainer);
+	}
+
+	// 마이페이지 정보
+	@Transactional(readOnly = true)
+	public TrainerResponse getInfo(Trainer trainer) {
+		return TrainerMapper.toResponse(trainer);
+	}
+
+	// 사장여부
+	@Transactional(readOnly = true)
+	public TrainerCheckResponse check(Trainer trainer) {
+		return TrainerMapper.toCheckResponse(trainer);
 	}
 
 	@Transactional(readOnly = true)


### PR DESCRIPTION
# 📝 제목
feat(도메인): 내용 요약

---

## 🔘 Part
- 도메인
Trainer
---

## 🔎 작업 내용
- 트레이너 마이페이지도 필요 하다고 하셔서 만들었고
- 사장 여부 체크는 마이페이지로 접속할때 화면이 모두 달라서 멤버인지 트레이너인지 체크하고 트레이너라면 사장인지 체크해야한다고 하셨습니다.
---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 멤버 쪽에서도 check API를 만들어주셔야 할 것 같습니다!
---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
