### PR TITLE
feat(trainer) : 트레이너 전체 조회 & 검색

### DIFF
--- a/src/main/java/org/helloworld/gymmate/common/config/SecurityConfig.java
+++ b/src/main/java/org/helloworld/gymmate/common/config/SecurityConfig.java
@@ -75,6 +75,7 @@ public class SecurityConfig {
 				"/crawl/**"
 			)
 			.requestMatchers(HttpMethod.GET, "/ptProduct", "/ptProduct/{id:\\d+}")
+			.requestMatchers(HttpMethod.GET, "/trainer/list")
 			//.requestMatchers(HttpMethod.GET, "/similar")
 			//.requestMatchers(HttpMethod.GET, "/reviews/{reviewId}/comments")
 			.requestMatchers(PathRequest.toH2Console());

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
@@ -65,7 +65,7 @@ public class GymService {
 		//TODO: 메소드 호출 seyeon
 		saveImages(images, existingGym);
 
-		//machineImage 업데이트
+		//machine 업데이트 (이미지 포함)
 		//TODO: 메소드 호출
 
 		//gymProduct 업데이트

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/ProductSearchRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/ProductSearchRequest.java
@@ -1,4 +1,0 @@
-package org.helloworld.gymmate.domain.pt.pt_product.dto;
-
-public class ProductSearchRequest {
-}

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/enums/PtProductSearchOption.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/enums/PtProductSearchOption.java
@@ -5,11 +5,12 @@ import java.util.Arrays;
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
 
-public enum SearchOption {
+public enum PtProductSearchOption {
 	NONE, TRAINER, PTPRODUCT, DISTRICT;
 
-	public static SearchOption from(String value) {
-		if (value == null) return NONE;
+	public static PtProductSearchOption from(String value) {
+		if (value == null)
+			return NONE;
 		return Arrays.stream(values())
 			.filter(option -> option.name().equalsIgnoreCase(value))
 			.findFirst()

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/enums/PtProductSortOption.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/enums/PtProductSortOption.java
@@ -5,11 +5,11 @@ import java.util.Arrays;
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
 
-public enum SortOption {
+public enum PtProductSortOption {
 	// TODO : 나중에 가격순 추가 가능
 	LATEST, SCORE, NEARBY;
 
-	public static SortOption from(String value) {
+	public static PtProductSortOption from(String value) {
 		return Arrays.stream(values())
 			.filter(option -> option.name().equalsIgnoreCase(value))
 			.findFirst()

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/repository/PtProductRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/repository/PtProductRepository.java
@@ -85,10 +85,10 @@ public interface PtProductRepository extends JpaRepository<PtProduct, Long> {
 		FROM pt_product p
 		JOIN gymmate_trainer t ON p.trainer_id = t.trainer_id
 		JOIN gym g ON t.gym_id = g.gym_id
-		WHERE (:searchOption = 'NONE' OR
-		       (:searchOption = 'TRAINER' AND t.trainer_name LIKE CONCAT('%', :searchTerm, '%')) OR
-		       (:searchOption = 'PTPRODUCT' AND p.info LIKE CONCAT('%', :searchTerm, '%')) OR
-		       (:searchOption = 'DISTRICT' AND g.address LIKE CONCAT('%', :searchTerm, '%')))
+		WHERE (:ptProductSearchOption = 'NONE' OR
+		       (:ptProductSearchOption = 'TRAINER' AND t.trainer_name LIKE CONCAT('%', :searchTerm, '%')) OR
+		       (:ptProductSearchOption = 'PTPRODUCT' AND p.info LIKE CONCAT('%', :searchTerm, '%')) OR
+		       (:ptProductSearchOption = 'DISTRICT' AND g.address LIKE CONCAT('%', :searchTerm, '%')))
 		ORDER BY ST_Distance_Sphere(
 		    ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326), g.location
 		) ASC
@@ -98,14 +98,14 @@ public interface PtProductRepository extends JpaRepository<PtProduct, Long> {
 			FROM pt_product p
 			JOIN gymmate_trainer t ON p.trainer_id = t.trainer_id
 			JOIN gym g ON t.gym_id = g.gym_id
-			WHERE (:searchOption = 'NONE' OR
-			       (:searchOption = 'TRAINER' AND t.trainer_name LIKE CONCAT('%', :searchTerm, '%')) OR
-			       (:searchOption = 'PTPRODUCT' AND p.info LIKE CONCAT('%', :searchTerm, '%')) OR
-			       (:searchOption = 'DISTRICT' AND g.address LIKE CONCAT('%', :searchTerm, '%')))
+			WHERE (:ptProductSearchOption = 'NONE' OR
+			       (:ptProductSearchOption = 'TRAINER' AND t.trainer_name LIKE CONCAT('%', :searchTerm, '%')) OR
+			       (:ptProductSearchOption = 'PTPRODUCT' AND p.info LIKE CONCAT('%', :searchTerm, '%')) OR
+			       (:ptProductSearchOption = 'DISTRICT' AND g.address LIKE CONCAT('%', :searchTerm, '%')))
 			""",
 		nativeQuery = true)
 	Page<PtProduct> findNearestPtProductsWithSearch(
 		@Param("x") Double x, @Param("y") Double y,
-		@Param("searchOption") String searchOption, @Param("searchTerm") String searchTerm,
+		@Param("ptProductSearchOption") String ptProductSearchOption, @Param("searchTerm") String searchTerm,
 		Pageable pageable);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/service/PtProductService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/service/PtProductService.java
@@ -17,8 +17,8 @@ import org.helloworld.gymmate.domain.pt.pt_product.dto.PtProductResponse;
 import org.helloworld.gymmate.domain.pt.pt_product.dto.PtProductsResponse;
 import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
 import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProductImage;
-import org.helloworld.gymmate.domain.pt.pt_product.enums.SearchOption;
-import org.helloworld.gymmate.domain.pt.pt_product.enums.SortOption;
+import org.helloworld.gymmate.domain.pt.pt_product.enums.PtProductSearchOption;
+import org.helloworld.gymmate.domain.pt.pt_product.enums.PtProductSortOption;
 import org.helloworld.gymmate.domain.pt.pt_product.mapper.PtProductMapper;
 import org.helloworld.gymmate.domain.pt.pt_product.repository.PtProductRepository;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
@@ -111,8 +111,8 @@ public class PtProductService {
 
 	public Page<PtProductsResponse> getProducts(String sortOption, String searchOption, String searchTerm,
 		int page, int pageSize, Double x, Double y) {
-		SortOption sort = SortOption.from(sortOption);
-		SearchOption search = SearchOption.from(searchOption);
+		PtProductSortOption sort = PtProductSortOption.from(sortOption);
+		PtProductSearchOption search = PtProductSearchOption.from(searchOption);
 		Pageable pageable = PageRequest.of(page, pageSize);
 
 		return switch (sort) {
@@ -122,7 +122,8 @@ public class PtProductService {
 		};
 	}
 
-	private Page<PtProductsResponse> fetchLatestProducts(SearchOption search, String searchTerm, Pageable pageable) {
+	private Page<PtProductsResponse> fetchLatestProducts(PtProductSearchOption search, String searchTerm,
+		Pageable pageable) {
 		Page<PtProduct> ptProducts = switch (search) {
 			case NONE -> ptProductRepository.findAllByOrderByPtProductIdDesc(pageable);
 			case TRAINER -> ptProductRepository.findByTrainerNameOrderByPtProductIdDesc(searchTerm, pageable);
@@ -133,7 +134,7 @@ public class PtProductService {
 		return fetchAndMapProducts(ptProducts, pageable);
 	}
 
-	private Page<PtProductsResponse> fetchScoreSortedProducts(SearchOption search, String searchTerm,
+	private Page<PtProductsResponse> fetchScoreSortedProducts(PtProductSearchOption search, String searchTerm,
 		Pageable pageable) {
 		Page<PtProduct> ptProducts = switch (search) {
 			case NONE -> ptProductRepository.findAllOrderByTrainerScoreDesc(pageable);
@@ -145,10 +146,12 @@ public class PtProductService {
 		return fetchAndMapProducts(ptProducts, pageable);
 	}
 
-	private Page<PtProductsResponse> fetchNearbyProductsUsingXY(SearchOption searchOption, String searchTerm,
+	private Page<PtProductsResponse> fetchNearbyProductsUsingXY(PtProductSearchOption ptProductSearchOption,
+		String searchTerm,
 		Pageable pageable, Double x, Double y) {
-		String searchValue = (searchOption == SearchOption.NONE) ? "" : searchTerm;
-		Page<PtProduct> ptProducts = ptProductRepository.findNearestPtProductsWithSearch(x, y, searchOption.name(),
+		String searchValue = (ptProductSearchOption == PtProductSearchOption.NONE) ? "" : searchTerm;
+		Page<PtProduct> ptProducts = ptProductRepository.findNearestPtProductsWithSearch(x, y,
+			ptProductSearchOption.name(),
 			searchValue, pageable);
 		return fetchAndMapProducts(ptProducts, pageable);
 	}
@@ -156,7 +159,7 @@ public class PtProductService {
 	public Page<PtProductsResponse> fetchNearbyProducts(String searchOption, String searchTerm,
 		int page, int pageSize, CustomOAuth2User customOAuth2User) {
 
-		SearchOption search = SearchOption.from(searchOption);
+		PtProductSearchOption search = PtProductSearchOption.from(searchOption);
 		Member member = memberService.findByUserId(customOAuth2User.getUserId());
 		Double x = Double.valueOf(member.getXField());
 		Double y = Double.valueOf(member.getYField());

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/repository/AwardRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/repository/AwardRepository.java
@@ -7,4 +7,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface AwardRepository extends JpaRepository<Award, Long> {
 	List<Award> findByTrainerId(Long trainerId);
+
+	List<Award> findByTrainerIdIn(List<Long> trainerIds);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/controller/TrainerController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/controller/TrainerController.java
@@ -1,7 +1,10 @@
 package org.helloworld.gymmate.domain.user.trainer.controller;
 
+import org.helloworld.gymmate.common.dto.PageDto;
+import org.helloworld.gymmate.common.mapper.PageMapper;
 import org.helloworld.gymmate.domain.user.trainer.dto.OwnerRegisterRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerCheckResponse;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerListResponse;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerModifyRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerProfileRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerRegisterRequest;
@@ -11,15 +14,19 @@ import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -92,8 +99,33 @@ public class TrainerController {
 	}
 
 	// 트레이너 전체조회 & 검색
-	// @GetMapping("/list")
-	// public ResponseEntity<TrainerListResponse> getTrainserList(){
-	//
-	// }
+	@GetMapping("/list")
+	@Validated
+	public ResponseEntity<PageDto<TrainerListResponse>> getTrainerList(
+		@RequestParam(defaultValue = "score") String sortOption,
+		@RequestParam(required = false) String searchOption,
+		@RequestParam(defaultValue = "") String searchTerm,
+		@RequestParam(defaultValue = "0") @Min(0) int page,
+		@RequestParam(defaultValue = "10") @Min(1) @Max(50) int pageSize,
+		@RequestParam(required = false, defaultValue = "127.0276") Double x,
+		@RequestParam(required = false, defaultValue = "37.4979") Double y
+	) {
+		return ResponseEntity.ok(PageMapper.toPageDto(
+			trainerService.getTrainers(sortOption, searchOption, searchTerm, page, pageSize, x, y)));
+	}
+
+	// (회원) 트레이너 가까운순 전체조회 & 검색
+	@GetMapping("/list/nearby")
+	@Validated
+	@PreAuthorize("hasRole('ROLE_MEMBER')")
+	public ResponseEntity<PageDto<TrainerListResponse>> getTrainerList(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+		@RequestParam(required = false) String searchOption,
+		@RequestParam(defaultValue = "") String searchTerm,
+		@RequestParam(defaultValue = "0") @Min(0) int page,
+		@RequestParam(defaultValue = "10") @Min(1) @Max(50) int pageSize
+	) {
+		return ResponseEntity.ok(PageMapper.toPageDto(
+			trainerService.getNearbyTrainers(searchOption, searchTerm, page, pageSize, customOAuth2User)));
+	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/controller/TrainerController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/controller/TrainerController.java
@@ -91,4 +91,9 @@ public class TrainerController {
 
 	}
 
+	// 트레이너 전체조회 & 검색
+	// @GetMapping("/list")
+	// public ResponseEntity<TrainerListResponse> getTrainserList(){
+	//
+	// }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerListResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerListResponse.java
@@ -1,0 +1,16 @@
+package org.helloworld.gymmate.domain.user.trainer.dto;
+
+import java.util.List;
+
+public record TrainerListResponse(
+	Long trainerId,
+	String trainerName,
+	String profile,
+	String intro,
+	List<String> awards,
+	// 현재 페이지에는 안쓰이는 정보..
+	String gender,
+	String career, // 경력
+	String field // 전문분야
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerListResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/dto/TrainerListResponse.java
@@ -3,14 +3,13 @@ package org.helloworld.gymmate.domain.user.trainer.dto;
 import java.util.List;
 
 public record TrainerListResponse(
-	Long trainerId,
-	String trainerName,
-	String profile,
-	String intro,
-	List<String> awards,
-	// 현재 페이지에는 안쓰이는 정보..
-	String gender,
+	Long trainerId, // 트레이너아이디 (api용)
+	String trainerName, // 이름
+	String profile, // 프로필이미지
+	Double score, // 평점
+	String intro, // 자기소개
 	String career, // 경력
-	String field // 전문분야
+	String field, // 전문분야
+	List<String> awards // 수상경력 (없으면 빈 리스트)
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/enums/TrainerSearchOption.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/enums/TrainerSearchOption.java
@@ -1,0 +1,19 @@
+package org.helloworld.gymmate.domain.user.trainer.enums;
+
+import java.util.Arrays;
+
+import org.helloworld.gymmate.common.exception.BusinessException;
+import org.helloworld.gymmate.common.exception.ErrorCode;
+
+public enum TrainerSearchOption {
+	NONE, TRAINER, DISTRICT;
+
+	public static TrainerSearchOption from(String value) {
+		if (value == null)
+			return NONE;
+		return Arrays.stream(values())
+			.filter(option -> option.name().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(() -> new BusinessException(ErrorCode.UNSUPPORTED_SEARCH_OPTION));
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/enums/TrainerSortOption.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/enums/TrainerSortOption.java
@@ -1,0 +1,17 @@
+package org.helloworld.gymmate.domain.user.trainer.enums;
+
+import java.util.Arrays;
+
+import org.helloworld.gymmate.common.exception.BusinessException;
+import org.helloworld.gymmate.common.exception.ErrorCode;
+
+public enum TrainerSortOption {
+	LATEST, SCORE, NEARBY;
+
+	public static TrainerSortOption from(String value) {
+		return Arrays.stream(values())
+			.filter(option -> option.name().equalsIgnoreCase(value))
+			.findFirst()
+			.orElseThrow(() -> new BusinessException(ErrorCode.UNSUPPORTED_SORT_OPTION));
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/mapper/TrainerMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/mapper/TrainerMapper.java
@@ -1,7 +1,12 @@
 package org.helloworld.gymmate.domain.user.trainer.mapper;
 
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
 import org.helloworld.gymmate.domain.user.enums.UserType;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerCheckResponse;
+import org.helloworld.gymmate.domain.user.trainer.dto.TrainerListResponse;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerResponse;
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
@@ -37,6 +42,19 @@ public class TrainerMapper {
 		return new TrainerCheckResponse(
 			UserType.TRAINER.toString(),
 			trainer.getIsOwner()
+		);
+	}
+
+	public static TrainerListResponse toListResponse(Trainer trainer, Map<Long, List<String>> awardsMap) {
+		return new TrainerListResponse(
+			trainer.getTrainerId(),
+			trainer.getTrainerName(),
+			trainer.getProfile(),
+			trainer.getScore(),
+			trainer.getIntro(),
+			trainer.getCareer(),
+			trainer.getField(),
+			awardsMap.getOrDefault(trainer.getTrainerId(), Collections.emptyList()) // 수상 경력 없으면 빈 리스트
 		);
 	}
 

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
@@ -21,6 +21,13 @@ public interface TrainerRepository extends JpaRepository<Trainer, Long> {
 
 	Optional<Trainer> findByTrainerId(Long trainerId);
 
+	Page<Trainer> findAllByOrderByTrainerIdDesc(Pageable pageable);
+
+	Page<Trainer> findByTrainerNameContainingIgnoreCaseOrderByTrainerIdDesc(String searchTerm, Pageable pageable);
+
+	@Query("SELECT t FROM Trainer t JOIN t.gym g WHERE g.address LIKE CONCAT('%', :searchTerm, '%') ORDER BY t.trainerId DESC")
+	Page<Trainer> findByGymAddressOrderByTrainerIdDesc(@Param("searchTerm") String searchTerm, Pageable pageable);
+
 	@Query(value = """
 		SELECT t.*
 		FROM gymmate_trainer t

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
@@ -6,7 +6,11 @@ import java.util.Set;
 
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
 @Repository
@@ -17,4 +21,28 @@ public interface TrainerRepository extends JpaRepository<Trainer, Long> {
 
 	Optional<Trainer> findByTrainerId(Long trainerId);
 
+	@Query(value = """
+		SELECT t.*
+		FROM gymmate_trainer t
+		JOIN gym g ON t.gym_id = g.gym_id
+		WHERE (:searchOption = 'NONE' OR
+		       (:searchOption = 'TRAINER' AND t.trainer_name LIKE CONCAT('%', :searchTerm, '%')) OR
+		       (:searchOption = 'DISTRICT' AND g.address LIKE CONCAT('%', :searchTerm, '%')))
+		ORDER BY ST_Distance_Sphere(
+		    ST_GeomFromText(CONCAT('POINT(', :y, ' ', :x, ')'), 4326), g.location
+		) ASC
+		""",
+		countQuery = """
+			SELECT COUNT(*)
+			FROM gymmate_trainer t
+			JOIN gym g ON t.gym_id = g.gym_id
+			WHERE (:searchOption = 'NONE' OR
+			       (:searchOption = 'TRAINER' AND t.trainer_name LIKE CONCAT('%', :searchTerm, '%')) OR
+			       (:searchOption = 'DISTRICT' AND g.address LIKE CONCAT('%', :searchTerm, '%')))
+			""",
+		nativeQuery = true)
+	Page<Trainer> findNearbyTrainersWithSearch(
+		@Param("x") Double x, @Param("y") Double y,
+		@Param("searchOption") String searchOption, @Param("searchTerm") String searchTerm,
+		Pageable pageable);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
@@ -28,6 +28,13 @@ public interface TrainerRepository extends JpaRepository<Trainer, Long> {
 	@Query("SELECT t FROM Trainer t JOIN t.gym g WHERE g.address LIKE CONCAT('%', :searchTerm, '%') ORDER BY t.trainerId DESC")
 	Page<Trainer> findByGymAddressOrderByTrainerIdDesc(@Param("searchTerm") String searchTerm, Pageable pageable);
 
+	Page<Trainer> findAllByOrderByScoreDesc(Pageable pageable);
+
+	Page<Trainer> findByTrainerNameContainingIgnoreCaseOrderByScoreDesc(String searchTerm, Pageable pageable);
+
+	@Query("SELECT t FROM Trainer t JOIN t.gym g WHERE LOWER(g.address) LIKE LOWER(CONCAT('%', :searchTerm, '%')) ORDER BY t.score DESC")
+	Page<Trainer> findByGymAddressOrderByScoreDesc(@Param("searchTerm") String searchTerm, Pageable pageable);
+
 	@Query(value = """
 		SELECT t.*
 		FROM gymmate_trainer t

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
@@ -140,10 +140,15 @@ public class TrainerService {
 		return fetchAndMapTrainers(trainers, pageable);
 	}
 
-	// TODO :
 	private Page<TrainerListResponse> fetchScoreSortedTrainers(TrainerSearchOption search, String searchTerm,
 		Pageable pageable) {
-		return null;
+		Page<Trainer> trainers = switch (search) {
+			case NONE -> trainerRepository.findAllByOrderByScoreDesc(pageable);
+			case TRAINER ->
+				trainerRepository.findByTrainerNameContainingIgnoreCaseOrderByScoreDesc(searchTerm, pageable);
+			case DISTRICT -> trainerRepository.findByGymAddressOrderByScoreDesc(searchTerm, pageable);
+		};
+		return fetchAndMapTrainers(trainers, pageable);
 	}
 
 	public Page<TrainerListResponse> getNearbyTrainers(String searchOption, String searchTerm, int page,

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
@@ -129,14 +129,19 @@ public class TrainerService {
 		};
 	}
 
-	// TODO :
-	private Page<TrainerListResponse> fetchScoreSortedTrainers(TrainerSearchOption search, String searchTerm,
+	private Page<TrainerListResponse> fetchLatestTrainers(TrainerSearchOption search, String searchTerm,
 		Pageable pageable) {
-		return null;
+		Page<Trainer> trainers = switch (search) {
+			case NONE -> trainerRepository.findAllByOrderByTrainerIdDesc(pageable);
+			case TRAINER ->
+				trainerRepository.findByTrainerNameContainingIgnoreCaseOrderByTrainerIdDesc(searchTerm, pageable);
+			case DISTRICT -> trainerRepository.findByGymAddressOrderByTrainerIdDesc(searchTerm, pageable);
+		};
+		return fetchAndMapTrainers(trainers, pageable);
 	}
 
-	// TODO : 
-	private Page<TrainerListResponse> fetchLatestTrainers(TrainerSearchOption search, String searchTerm,
+	// TODO :
+	private Page<TrainerListResponse> fetchScoreSortedTrainers(TrainerSearchOption search, String searchTerm,
 		Pageable pageable) {
 		return null;
 	}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/service/TrainerService.java
@@ -139,7 +139,7 @@ public class TrainerService {
 	}
 
 	@Transactional(readOnly = true)
-	private Page<TrainerListResponse> fetchLatestTrainers(TrainerSearchOption search, String searchTerm,
+	public Page<TrainerListResponse> fetchLatestTrainers(TrainerSearchOption search, String searchTerm,
 		Pageable pageable) {
 		Page<Trainer> trainers = switch (search) {
 			case NONE -> trainerRepository.findAllByOrderByTrainerIdDesc(pageable);
@@ -151,7 +151,7 @@ public class TrainerService {
 	}
 
 	@Transactional(readOnly = true)
-	private Page<TrainerListResponse> fetchScoreSortedTrainers(TrainerSearchOption search, String searchTerm,
+	public Page<TrainerListResponse> fetchScoreSortedTrainers(TrainerSearchOption search, String searchTerm,
 		Pageable pageable) {
 		Page<Trainer> trainers = switch (search) {
 			case NONE -> trainerRepository.findAllByOrderByScoreDesc(pageable);
@@ -173,7 +173,8 @@ public class TrainerService {
 		return fetchNearbyTrainersUsingXY(search, searchTerm, pageable, x, y);
 	}
 
-	private Page<TrainerListResponse> fetchNearbyTrainersUsingXY(TrainerSearchOption trainerSearchOption,
+	@Transactional(readOnly = true)
+	public Page<TrainerListResponse> fetchNearbyTrainersUsingXY(TrainerSearchOption trainerSearchOption,
 		String searchTerm, Pageable pageable, Double x, Double y) {
 		String searchValue = (trainerSearchOption == TrainerSearchOption.NONE) ? "" : searchTerm;
 		Page<Trainer> trainers = trainerRepository.findNearbyTrainersWithSearch(x, y,
@@ -183,7 +184,7 @@ public class TrainerService {
 	}
 
 	@Transactional(readOnly = true)
-	protected Page<TrainerListResponse> fetchAndMapTrainers(Page<Trainer> trainers, Pageable pageable) {
+	public Page<TrainerListResponse> fetchAndMapTrainers(Page<Trainer> trainers, Pageable pageable) {
 		List<Long> trainerIds = trainers.stream()
 			.map(Trainer::getTrainerId)
 			.toList();


### PR DESCRIPTION
# 📝 제목
feat(trainer) : 트레이너 전체 조회 & 검색

---

## 🔘 Part
- trainer

---

## 🔎 작업 내용
- SortOption, SearchOption 트레이너용 / PT상품용 분리
- 트레이너 위치 기반 가까운순 조회 구현
- 트레이너 점수 정렬 & 검색
- 트레이너 최신순 정렬 & 검색
---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
