### PR TITLE
refactor(pt):name필드 추가

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductCreateRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductCreateRequest.java
@@ -4,11 +4,16 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record PtProductCreateRequest (
+public record PtProductCreateRequest(
+
+	@NotBlank(message = "이름은 필수 입력 값입니다.")
+	String ptProductName,
+
 	@NotBlank(message = "정보는 필수 입력 값입니다.")
 	String info,
 
 	@NotNull(message = "PT 수업 요금은 필수 입력 값입니다.")
 	@Min(value = 0, message = "PT 수업 요금은 0원 이상이어야 합니다.")
 	Long ptProductFee
-){}
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductModifyRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductModifyRequest.java
@@ -6,7 +6,10 @@ import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 
-public record PtProductModifyRequest (
+public record PtProductModifyRequest(
+	@NotBlank(message = "이름은 필수 입력 값입니다.")
+	String ptProductName,
+
 	@NotBlank(message = "정보는 필수 입력 값입니다.")
 	String info,
 
@@ -15,4 +18,5 @@ public record PtProductModifyRequest (
 	Long ptProductFee,
 
 	List<String> deleteImageIds
-){}
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductResponse.java
@@ -4,6 +4,7 @@ import java.util.List;
 
 public record PtProductResponse(
 	Long ptProductId,
+	String productName,
 	Trainer trainer,
 	String ptInfo,
 	Long fee,

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductsResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/dto/PtProductsResponse.java
@@ -2,6 +2,7 @@ package org.helloworld.gymmate.domain.pt.pt_product.dto;
 
 public record PtProductsResponse(
 	Long ptProductId,
+	String productName,
 	PtTrainerResponse trainer,
 	String info,
 	Long ptProductFee
@@ -12,5 +13,6 @@ public record PtProductsResponse(
 		String gender,
 		String profile,
 		Double score
-	) {}
+	) {
+	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/entity/PtProduct.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/entity/PtProduct.java
@@ -30,6 +30,9 @@ public class PtProduct {
 	@Column(name = "pt_product_id", nullable = false)
 	private Long ptProductId;
 
+	@Column(name = "pt_product_name", nullable = false)
+	private String ptProductName;
+
 	@Column(name = "info", nullable = false)
 	private String info;
 

--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/mapper/PtProductMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/mapper/PtProductMapper.java
@@ -17,6 +17,7 @@ import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 public class PtProductMapper {
 	public static PtProduct toEntity(PtProductCreateRequest request, Long trainerId) {
 		return PtProduct.builder()
+			.ptProductName(request.ptProductName())
 			.info(request.info())
 			.ptProductFee(request.ptProductFee())
 			.trainerId(trainerId)
@@ -44,6 +45,7 @@ public class PtProductMapper {
 		Map<Long, PtProductsResponse.PtTrainerResponse> trainerMap) {
 		return new PtProductsResponse(
 			ptProduct.getPtProductId(),
+			ptProduct.getPtProductName(),
 			trainerMap.get(ptProduct.getTrainerId()), // 트레이너 정보 매핑
 			ptProduct.getInfo(),
 			ptProduct.getPtProductFee()
@@ -53,6 +55,7 @@ public class PtProductMapper {
 	public static PtProductResponse toDto(PtProduct ptProduct, Trainer trainer, List<Award> awards, Gym gym) {
 		return new PtProductResponse(
 			ptProduct.getPtProductId(),
+			ptProduct.getPtProductName(),
 			new PtProductResponse.Trainer(
 				trainer.getTrainerId(),
 				trainer.getTrainerName(),


### PR DESCRIPTION
## 📝 refactor(pt):name필드 추가


### 🔘 Part
- pt_product


### 🔎 작업 내용
- ptProduct 엔티티 : name필드추가
- Dto: name 필드 추가
  - ptProductResponse,ptProductsResonse,ptProductCreateRequest,ptProductModifyRequest
- Mapper : name 변환 추가


### 🖼️ 
<img width="696" alt="스크린샷 2025-04-03 오전 10 45 39" src="https://github.com/user-attachments/assets/8cf219f5-9a5f-404e-abe8-7b652713145d" />


### 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료
- ptProduct 생성,수정,삭제 API 테스트 완료


### ➕ 이슈 링크
- [GYMMATE-268](https://dia19.atlassian.net/browse/GYMMATE-268)




[GYMMATE-268]: https://dia19.atlassian.net/browse/GYMMATE-268?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ