### PR TITLE
feat(gymProduct): 헬스장 이용권 등록 구현 

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
@@ -1,6 +1,7 @@
 package org.helloworld.gymmate.domain.gym.gymInfo.controller;
 
 import java.util.List;
+import java.util.Map;
 
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
@@ -32,13 +33,15 @@ public class GymController {
 	// 제휴 헬스장 등록
 	@PreAuthorize("hasRole('ROLE_TRAINER')")
 	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<Long> registerPartnerGym(
+	public ResponseEntity<Map<String, Long>> registerPartnerGym(
 		@RequestPart("request") @Valid RegisterGymRequest request,
 		@RequestPart(value = "images", required = false) List<MultipartFile> images,
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 
-		return ResponseEntity.status(HttpStatus.CREATED).body(
-			gymService.registerPartnerGym(request, images, customOAuth2User.getUserId()));
+		Long partnerGymId = gymService.registerPartnerGym(request, images, customOAuth2User.getUserId());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(Map.of("partnerGymId", partnerGymId));
+
 	}
 
 	// 제휴 헬스장 수정

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/RegisterGymRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/RegisterGymRequest.java
@@ -2,6 +2,8 @@ package org.helloworld.gymmate.domain.gym.gymInfo.dto.request;
 
 import java.util.List;
 
+import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
+
 public record RegisterGymRequest(
 	Long gymId,
 	GymInfoRequest gymInfoRequest,

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
@@ -42,7 +42,7 @@ public class PartnerGym {
 	@JoinColumn(name = "gym_id", unique = true, nullable = false)
 	private Gym gym;
 
-	@OneToMany(mappedBy = "Partner_gym", cascade = CascadeType.ALL, orphanRemoval = true)
+	@OneToMany(mappedBy = "partnerGym", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<GymProduct> gymProducts = new ArrayList<>();
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
@@ -45,9 +45,4 @@ public class PartnerGym {
 	@OneToMany(mappedBy = "partnerGym", cascade = CascadeType.ALL, orphanRemoval = true)
 	@Builder.Default
 	private List<GymProduct> gymProducts = new ArrayList<>();
-
-	public void addGymProduct(GymProduct gymProduct) {
-		this.gymProducts.add(gymProduct);
-		gymProduct.assignTo(this);
-	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
@@ -1,5 +1,11 @@
 package org.helloworld.gymmate.domain.gym.gymInfo.entity;
 
+import java.util.ArrayList;
+import java.util.List;
+
+import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+
+import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.FetchType;
@@ -7,6 +13,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToMany;
 import jakarta.persistence.OneToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -34,4 +41,13 @@ public class PartnerGym {
 	@OneToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "gym_id", unique = true, nullable = false)
 	private Gym gym;
+
+	@OneToMany(mappedBy = "Partner_gym", cascade = CascadeType.ALL, orphanRemoval = true)
+	@Builder.Default
+	private List<GymProduct> gymProducts = new ArrayList<>();
+
+	public void addGymProduct(GymProduct gymProduct) {
+		this.gymProducts.add(gymProduct);
+		gymProduct.assignTo(this);
+	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
@@ -16,11 +16,11 @@ import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymInfo.mapper.GymMapper;
 import org.helloworld.gymmate.domain.gym.gymInfo.repository.GymRepository;
 import org.helloworld.gymmate.domain.gym.gymInfo.repository.PartnerGymRepository;
-import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
-import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
 import org.helloworld.gymmate.domain.gym.gymProduct.mapper.GymProductMapper;
 import org.helloworld.gymmate.domain.gym.gymProduct.repository.GymProductRepository;
+import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
+import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -67,11 +67,7 @@ public class GymService {
 		facility.update(request.gymInfoRequest().facilityRequest());
 
 		// gymImage 업데이트
-		//TODO: 메소드 호출 seyeon
 		saveImages(images, existingGym);
-
-		//machineImage 업데이트
-		//TODO: 메소드 호출
 
 		//gymProduct 업데이트
 		List<GymProduct> gymProducts = request.gymProductRequest().stream()

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/dto/GymProductRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/dto/GymProductRequest.java
@@ -1,4 +1,4 @@
-package org.helloworld.gymmate.domain.gym.gymInfo.dto.request;
+package org.helloworld.gymmate.domain.gym.gymProduct.dto;
 
 import jakarta.validation.constraints.NotNull;
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
@@ -39,11 +39,7 @@ public class GymProduct {
 	@Column(name = "on_sale", nullable = false)
 	private Boolean onSale;
 
-	@ManyToOne(optional = true, fetch = FetchType.LAZY)
+	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "partner_gym_id")
 	private PartnerGym partnerGym;
-
-	public void assignTo(PartnerGym partnerGym) {
-		this.partnerGym = partnerGym;
-	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
@@ -1,0 +1,49 @@
+package org.helloworld.gymmate.domain.gym.gymProduct.entity;
+
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "gym_product")
+public class GymProduct {
+
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "gym_product_id")
+	private Long gymProductId;
+
+	@Column(name = "gym_product_fee", nullable = false)
+	private Integer gymProductFee;
+
+	@Column(name = "gym_product_month", nullable = false)
+	private Integer gymProductMonth;
+
+	@Column(name = "on_sale", nullable = false)
+	private Boolean onSale;
+
+	@ManyToOne(optional = true, fetch = FetchType.LAZY)
+	@JoinColumn(name = "partner_gym_id")
+	private PartnerGym partnerGym;
+
+	public void assignTo(PartnerGym partnerGym) {
+		this.partnerGym = partnerGym;
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/mapper/GymProductMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/mapper/GymProductMapper.java
@@ -1,0 +1,16 @@
+package org.helloworld.gymmate.domain.gym.gymProduct.mapper;
+
+import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
+import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+
+import jakarta.validation.Valid;
+
+public class GymProductMapper {
+	public static GymProduct toEntityWithoutPartnerGym(@Valid GymProductRequest request) {
+		return GymProduct.builder()
+			.gymProductFee(request.gymProductFee())
+			.gymProductMonth(request.gymProductMonth())
+			.onSale(true)
+			.build();
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/mapper/GymProductMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/mapper/GymProductMapper.java
@@ -1,16 +1,18 @@
 package org.helloworld.gymmate.domain.gym.gymProduct.mapper;
 
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
 
 import jakarta.validation.Valid;
 
 public class GymProductMapper {
-	public static GymProduct toEntityWithoutPartnerGym(@Valid GymProductRequest request) {
+	public static GymProduct toEntity(@Valid GymProductRequest request, PartnerGym partnerGym) {
 		return GymProduct.builder()
 			.gymProductFee(request.gymProductFee())
 			.gymProductMonth(request.gymProductMonth())
 			.onSale(true)
+			.partnerGym(partnerGym)
 			.build();
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/repository/GymProductRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/repository/GymProductRepository.java
@@ -1,0 +1,9 @@
+package org.helloworld.gymmate.domain.gym.gymProduct.repository;
+
+import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface GymProductRepository extends JpaRepository<GymProduct, Long> {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/service/GymProductService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/service/GymProductService.java
@@ -1,0 +1,28 @@
+package org.helloworld.gymmate.domain.gym.gymProduct.service;
+
+import java.util.List;
+
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
+import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
+import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+import org.helloworld.gymmate.domain.gym.gymProduct.mapper.GymProductMapper;
+import org.helloworld.gymmate.domain.gym.gymProduct.repository.GymProductRepository;
+import org.springframework.stereotype.Service;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class GymProductService {
+
+	private final GymProductRepository gymProductRepository;
+
+	public void registerGymProducts(List<GymProductRequest> requests, PartnerGym partnerGym) {
+		List<GymProduct> gymProducts = requests.stream()
+			.map(request -> GymProductMapper.toEntity(request, partnerGym))
+			.toList();
+
+		gymProductRepository.saveAll(gymProducts);
+	}
+
+}


### PR DESCRIPTION
# 📝 제목
feat(gymProduct): 헬스장 이용권 

---

## 🔘 Part

- PartnerGym

---

## 🔎 작업 내용
- `GymInfo/dto/request`에 있던 GymproductRequest를 별도의 패키지인 `gymProduct`로 이동했습니다.
- gymProduct는 PartnerGym 생성 이전에 요청(request)으로 전달되므로, 우선 DB에 partnerGym 없이 저장한 후, PartnerGym이 생성된 이후 addGymProduct() 메서드를 통해 연관관계를 설정하는 방식으로 구현했습니다.
(이로써 GymProduct 등록 시 partnerGym의 지연 생성 문제를 회피하면서, 이후 1:N 연관관계를 안전하게 맺을 수 있도록 처리했습니다.)
---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
-  GYMMATE-189

---
