### PR TITLE
feat(reservation): PT예약 등록 로직

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -4,6 +4,7 @@ import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
 import org.helloworld.gymmate.domain.reservation.service.ReservationService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -32,6 +33,7 @@ public class ReservationController {
 	 1. ptProduct_id로 ptProduct 정보 조회
 	 2. ptProduct 정보, reservationRequest 정보, member_id 로 reservation객체 생성&저장
 	 */
+	@PreAuthorize("hasRole('ROLE_MEMBER')")
 	@PostMapping("/ptProduct/{ptProductId}")
 	public ResponseEntity<Long> register(
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -1,0 +1,49 @@
+package org.helloworld.gymmate.domain.reservation.controller;
+
+import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.service.ReservationService;
+import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import lombok.RequiredArgsConstructor;
+
+@RestController
+@RequestMapping("/reservation")
+@RequiredArgsConstructor
+public class ReservationController {
+	private final ReservationService reservationService;
+
+	/*
+	 예약 생성 API
+
+	 Controller -> Service 전달 정보:
+	 1. ReservationRequest: 사용자가 입력한 예약 정보
+	 2. memberId: 예약 주체인 member의 ID (멤버 객체 조회는 서비스에서 수행)
+	 	- customOAuth2User.getUserId()로 구함.
+	 3. ptProductId: 예약할 PT 상품의 ID
+
+	 Service 역할:
+	 1. ptProduct_id로 ptProduct 정보 조회
+	 2. ptProduct 정보, reservationRequest 정보, member_id 로 reservation객체 생성&저장
+	 */
+	@PostMapping("/ptProduct/{ptProductId}")
+	public ResponseEntity<Long> register(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+		@PathVariable Long ptProductId,
+		@RequestBody ReservationRequest request
+	) {
+		return ResponseEntity.ok()
+			.body(reservationService.register(
+				customOAuth2User.getUserId(),
+				ptProductId,
+				request
+			));
+	}
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
@@ -1,0 +1,15 @@
+package org.helloworld.gymmate.domain.reservation.dto;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+public record ReservationRequest(
+	Long reservationId,
+	String productName,
+	LocalDate date,
+	LocalTime time,
+	Integer price,
+	LocalDate cancelDate,
+	LocalDate completedDate
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
@@ -8,7 +8,7 @@ public record ReservationRequest(
 	String productName,
 	LocalDate date,
 	LocalTime time,
-	Integer price,
+	Long price,
 	LocalDate cancelDate,
 	LocalDate completedDate
 ) {

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/entity/Reservation.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/entity/Reservation.java
@@ -1,0 +1,34 @@
+package org.helloworld.gymmate.domain.reservation.entity;
+
+import java.time.LocalDate;
+import java.time.LocalTime;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+
+public class Reservation {
+	@Id
+	@GeneratedValue(strategy = GenerationType.IDENTITY)
+	@Column(name = "reservation_id", nullable = false)
+	private Long reservationId;
+
+	@Column(name = "product_name", nullable = false)
+	private String productName;
+
+	@Column(nullable = false)
+	private LocalDate date;
+
+	@Column(nullable = false)
+	private LocalTime time;
+
+	@Column(nullable = false)
+	private Integer price;
+
+	@Column(name = "cancel_date")
+	private LocalDate cancelDate;
+
+	@Column(name = "completed_date")
+	private LocalDate completedDate;
+}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/entity/Reservation.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/entity/Reservation.java
@@ -4,10 +4,23 @@ import java.time.LocalDate;
 import java.time.LocalTime;
 
 import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
 
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "reservation")
 public class Reservation {
 	@Id
 	@GeneratedValue(strategy = GenerationType.IDENTITY)
@@ -24,11 +37,17 @@ public class Reservation {
 	private LocalTime time;
 
 	@Column(nullable = false)
-	private Integer price;
+	private Long price;
 
 	@Column(name = "cancel_date")
 	private LocalDate cancelDate;
 
 	@Column(name = "completed_date")
 	private LocalDate completedDate;
+
+	@Column(name = "member_id")
+	private Long memberId;
+
+	@Column(name = "trainer_id")
+	private Long trainerId;
 }

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/repository/ReservationRepository.java
@@ -1,0 +1,10 @@
+package org.helloworld.gymmate.domain.reservation.repository;
+
+import org.helloworld.gymmate.domain.reservation.entity.Reservation;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReservationRepository extends JpaRepository<Reservation, Long> {
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
@@ -1,0 +1,47 @@
+package org.helloworld.gymmate.domain.reservation.service;
+
+import org.helloworld.gymmate.common.exception.BusinessException;
+import org.helloworld.gymmate.common.exception.ErrorCode;
+import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
+import org.helloworld.gymmate.domain.pt.pt_product.repository.PtProductRepository;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.entity.Reservation;
+import org.helloworld.gymmate.domain.reservation.repository.ReservationRepository;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class ReservationService {
+
+	private final ReservationRepository reservationRepository;
+	private final PtProductRepository ptProductRepository;
+
+	/*
+	 예약 생성 로직
+	 1. ptProduct_id로 ptProduct 객체 조회
+	 2. ptProduct 정보, reservationRequest 정보, member_id 로 reservation객체 생성&저장
+	  - ptProduct 객체 에서 ptProductName,TrainerId,ptProductFee 조회
+	 */
+	@Transactional
+	public Long register(Long userId, Long ptProductId, ReservationRequest request) {
+		// 1) PT 상품 조회
+		PtProduct ptProduct = ptProductRepository.findById(ptProductId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.PTPRODUCT_NOT_FOUND));
+
+		// 2) 예약 엔티티 생성
+		Reservation reservation = Reservation.builder()
+			.productName(ptProduct.getPtProductName())        // 스냅샷
+			.trainerId(ptProduct.getTrainerId())     // 스냅샷
+			.date(request.date())
+			.time(request.time())
+			.price(ptProduct.getPtProductFee())      // 스냅샷
+			.memberId(userId)
+			.build();
+
+		// 3) 저장 및 ID 반환
+		return reservationRepository.save(reservation).getReservationId();
+	}
+}


### PR DESCRIPTION
## 📝 feat(reservation): PT예약 등록 로직 


## 🔘 Part
- reservation


## 🔎 작업 내용
- 컨트롤러 : userId, ReservationRequest,ptProductId 를 서비스에 전달 
- 서비스 : userId, ReservationRequest,ptProductId 로 예약정보, 멤버id,트레이너id를 담은 예약 생성&저장
- ReservationRequest DTO 



## 🖼️ 이미지 첨부

<img width="865" alt="postman" src="https://github.com/user-attachments/assets/1d16f2cb-d829-4c45-90af-565bc1921a79" />
<img width="612" alt="db" src="https://github.com/user-attachments/assets/679b1df6-2a48-4a32-b56c-98ea440a0881" />


## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

