### PR TITLE
refactor&test(reservation): 유효성 검사,mapper, 함수분리,httpStatus

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/service/PtProductService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/pt_product/service/PtProductService.java
@@ -90,7 +90,7 @@ public class PtProductService {
 		ptProduct.getPtProductImages().addAll(ptProductImages);
 	}
 
-	private PtProduct findProductOrThrow(Long productId) {
+	public PtProduct findProductOrThrow(Long productId) {
 		return ptProductRepository.findById(productId)
 			.orElseThrow(() -> new BusinessException(ErrorCode.PTPRODUCT_NOT_FOUND));
 	}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -3,6 +3,7 @@ package org.helloworld.gymmate.domain.reservation.controller;
 import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
 import org.helloworld.gymmate.domain.reservation.service.ReservationService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
@@ -41,7 +42,7 @@ public class ReservationController {
 		@PathVariable Long ptProductId,
 		@Valid @RequestBody ReservationRequest request
 	) {
-		return ResponseEntity.ok()
+		return ResponseEntity.status(HttpStatus.CREATED)
 			.body(reservationService.register(
 				customOAuth2User.getUserId(),
 				ptProductId,

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -12,6 +12,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -38,7 +39,7 @@ public class ReservationController {
 	public ResponseEntity<Long> register(
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@PathVariable Long ptProductId,
-		@RequestBody ReservationRequest request
+		@Valid @RequestBody ReservationRequest request
 	) {
 		return ResponseEntity.ok()
 			.body(reservationService.register(

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
@@ -1,15 +1,36 @@
 package org.helloworld.gymmate.domain.reservation.dto;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
+
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 
 public record ReservationRequest(
 	Long reservationId,
+
+	@NotBlank(message = "상품명은 필수입니다")
 	String productName,
+
+	@NotNull(message = "예약 날짜는 필수입니다")
 	LocalDate date,
-	LocalTime time,
+
+	@NotNull(message = "예약 시간은 필수입니다")
+	@Min(value = 0, message = "예약 시간은 0시 이상이어야 합니다")
+	@Max(value = 23, message = "예약 시간은 23시 이하여야 합니다")
+	Integer time,
+
+	@NotNull(message = "가격은 필수입니다")
+	@Positive(message = "가격은 0보다 커야 합니다")
 	Long price,
-	LocalDate cancelDate,
-	LocalDate completedDate
+
+	LocalDate cancelDate, // 예약 생성 시에는 필요 없음
+
+	LocalDate completedDate // 예약 생성 시에는 필요 없음
 ) {
+	// TODO: 추가 유효성 검사를 위한 생성자:
+	// 1. 예약날짜와 시간이 현재보다 이후인지.
+	// 2. cancelDate가 예약날짜 이후인지
 }

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/entity/Reservation.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/entity/Reservation.java
@@ -1,7 +1,6 @@
 package org.helloworld.gymmate.domain.reservation.entity;
 
 import java.time.LocalDate;
-import java.time.LocalTime;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -34,7 +33,7 @@ public class Reservation {
 	private LocalDate date;
 
 	@Column(nullable = false)
-	private LocalTime time;
+	private Integer time;
 
 	@Column(nullable = false)
 	private Long price;

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/mapper/ReservationMapper.java
@@ -6,9 +6,9 @@ import org.helloworld.gymmate.domain.reservation.entity.Reservation;
 
 public class ReservationMapper {
 
-	/**
-	 * PT 상품과 예약 요청과 유저Id로부터 예약 엔티티 생성
-	 * 예약 시점의 PT 상품 정보를 스냅샷으로 저장
+	/*
+	 PT 상품과 예약 요청과 유저Id로부터 예약 엔티티 생성
+	 예약 시점의 PT 상품 정보를 스냅샷으로 저장
 	 */
 	public static Reservation toEntity(
 		PtProduct ptProduct,

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/mapper/ReservationMapper.java
@@ -1,0 +1,27 @@
+package org.helloworld.gymmate.domain.reservation.mapper;
+
+import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.entity.Reservation;
+
+public class ReservationMapper {
+
+	/**
+	 * PT 상품과 예약 요청과 유저Id로부터 예약 엔티티 생성
+	 * 예약 시점의 PT 상품 정보를 스냅샷으로 저장
+	 */
+	public static Reservation toEntity(
+		PtProduct ptProduct,
+		ReservationRequest request,
+		Long userId
+	) {
+		return Reservation.builder()
+			.productName(ptProduct.getPtProductName())  // 스냅샷
+			.trainerId(ptProduct.getTrainerId())       // 스냅샷
+			.date(request.date())
+			.time(request.time())
+			.price(ptProduct.getPtProductFee())        // 스냅샷
+			.memberId(userId)
+			.build();
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
@@ -1,11 +1,10 @@
 package org.helloworld.gymmate.domain.reservation.service;
 
-import org.helloworld.gymmate.common.exception.BusinessException;
-import org.helloworld.gymmate.common.exception.ErrorCode;
 import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
-import org.helloworld.gymmate.domain.pt.pt_product.repository.PtProductRepository;
+import org.helloworld.gymmate.domain.pt.pt_product.service.PtProductService;
 import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
 import org.helloworld.gymmate.domain.reservation.entity.Reservation;
+import org.helloworld.gymmate.domain.reservation.mapper.ReservationMapper;
 import org.helloworld.gymmate.domain.reservation.repository.ReservationRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -17,7 +16,7 @@ import lombok.RequiredArgsConstructor;
 public class ReservationService {
 
 	private final ReservationRepository reservationRepository;
-	private final PtProductRepository ptProductRepository;
+	private final PtProductService ptProductService;
 
 	/*
 	 예약 생성 로직
@@ -28,18 +27,9 @@ public class ReservationService {
 	@Transactional
 	public Long register(Long userId, Long ptProductId, ReservationRequest request) {
 		// 1) PT 상품 조회
-		PtProduct ptProduct = ptProductRepository.findById(ptProductId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.PTPRODUCT_NOT_FOUND));
-
+		PtProduct ptProduct = ptProductService.findProductOrThrow(ptProductId);
 		// 2) 예약 엔티티 생성
-		Reservation reservation = Reservation.builder()
-			.productName(ptProduct.getPtProductName())        // 스냅샷
-			.trainerId(ptProduct.getTrainerId())     // 스냅샷
-			.date(request.date())
-			.time(request.time())
-			.price(ptProduct.getPtProductFee())      // 스냅샷
-			.memberId(userId)
-			.build();
+		Reservation reservation = ReservationMapper.toEntity(ptProduct, request, userId);
 
 		// 3) 저장 및 ID 반환
 		return reservationRepository.save(reservation).getReservationId();

--- a/src/test/java/org/helloworld/gymmate/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/org/helloworld/gymmate/reservation/service/ReservationServiceTest.java
@@ -1,0 +1,99 @@
+package org.helloworld.gymmate.reservation.service;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+import java.time.LocalDate;
+
+import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
+import org.helloworld.gymmate.domain.pt.pt_product.service.PtProductService;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.entity.Reservation;
+import org.helloworld.gymmate.domain.reservation.repository.ReservationRepository;
+import org.helloworld.gymmate.domain.reservation.service.ReservationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import jakarta.persistence.EntityNotFoundException;
+
+@ExtendWith(MockitoExtension.class)
+class ReservationServiceTest {
+	@InjectMocks
+	private ReservationService reservationService;
+
+	@Mock
+	private PtProductService ptProductService;
+
+	@Mock
+	private ReservationRepository reservationRepository;
+
+	@Test
+	@DisplayName("예약 생성 성공")
+	void registerSuccess() {
+		// given
+		Long userId = 1L;
+		Long ptProductId = 1L;
+		ReservationRequest request = new ReservationRequest(
+			null,                   // reservationId
+			"PT 상품",              // productName
+			LocalDate.now().plusDays(1), // date (내일)
+			14,                     // time (14시)
+			100000L,               // price
+			null,                  // cancelDate
+			null                   // completedDate
+		);
+
+		PtProduct ptProduct = PtProduct.builder()
+			.ptProductId(ptProductId)
+			.ptProductName("PT 상품")
+			.trainerId(2L)
+			.ptProductFee(100000L)
+			.build();
+
+		Reservation savedReservation = Reservation.builder()
+			.reservationId(1L)
+			.productName(ptProduct.getPtProductName())
+			.trainerId(ptProduct.getTrainerId())
+			.date(request.date())
+			.time(request.time())
+			.price(ptProduct.getPtProductFee())
+			.memberId(userId)
+			.build();
+
+		// when
+		when(ptProductService.findProductOrThrow(ptProductId)).thenReturn(ptProduct);
+		when(reservationRepository.save(any(Reservation.class))).thenReturn(savedReservation);
+
+		Long result = reservationService.register(userId, ptProductId, request);
+
+		// then
+		assertThat(result).isEqualTo(savedReservation.getReservationId());
+		verify(ptProductService).findProductOrThrow(ptProductId);
+		verify(reservationRepository).save(any(Reservation.class));
+	}
+
+	@Test
+	@DisplayName("존재하지 않는 PT 상품으로 예약 시도 시 예외 발생")
+	void registerWithNonExistentProduct() {
+		// given
+		Long userId = 1L;
+		Long ptProductId = 999L;
+		ReservationRequest request = new ReservationRequest(
+			null, "PT 상품", LocalDate.now().plusDays(1), 14, 100000L, null, null
+		);
+
+		// when
+		when(ptProductService.findProductOrThrow(ptProductId))
+			.thenThrow(new EntityNotFoundException("존재하지 않는 PT 상품입니다."));
+
+		// then
+		assertThrows(EntityNotFoundException.class, () ->
+			reservationService.register(userId, ptProductId, request)
+		);
+	}
+}


### PR DESCRIPTION
## 📝refactor&test(reservation): 유효성 검사,mapper, 함수분리,httpStatus



## 🔎 작업 내용
**리팩토링**
- **DTO 유효성 검사** : @ NotBlank , @ min,max 등
   - @ Valid 추가 
- **mapper** : toEntity -> ptProduct,ReservationRequest,userId받아서 Reservation객체 생성
- **함수분리** : ptProduceRepository 호출 대신->ptProductService.findProductOrThrow함수 호출
- **httpStatus** : ok -> HttpStatus.CREATED  

**테스트**
- 서비스 테스트 코드 작성 

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료 -> 서비스 테스트 완료
- '예약 생성', '존재하지 않는 PT 상품으로 예약 시도 시 예외 발생' -> 서비스 테스트 통과 



## ➕ 이슈 링크
- [GYMMATE-153](https://dia19.atlassian.net/browse/GYMMATE-153)


[GYMMATE-153]: https://dia19.atlassian.net/browse/GYMMATE-153?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ