### PR TITLE
feat(gym) : 크롤링 데이터 수집 중 가짜 머신 정보 삽입

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/Gym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/Gym.java
@@ -23,12 +23,14 @@ import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
+import lombok.With;
 
 @Entity
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Builder
+@With
 @Table(name = "gym")
 public class Gym {
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/machine/enums/GymMachine.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/machine/enums/GymMachine.java
@@ -1,0 +1,40 @@
+package org.helloworld.gymmate.domain.gym.machine.enums;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public enum GymMachine {
+	BENCH_PRESS("벤치 프레스", "s3://your-bucket/bench_press.jpg"),
+	SQUAT_RACK("스쿼트 랙", "s3://your-bucket/squat_rack.jpg"),
+	LAT_PULLDOWN("랫 풀다운", "s3://your-bucket/lat_pulldown.jpg"),
+	LEG_PRESS("레그 프레스", "s3://your-bucket/leg_press.jpg"),
+	CHEST_PRESS("체스트 프레스", "s3://your-bucket/chest_press.jpg"),
+	PEC_DECK("펙덱 머신", "s3://your-bucket/pec_deck.jpg"),
+	SHOULDER_PRESS("숄더 프레스", "s3://your-bucket/shoulder_press.jpg"),
+	LEG_EXTENSION("레그 익스텐션", "s3://your-bucket/leg_extension.jpg"),
+	LEG_CURL("레그 컬", "s3://your-bucket/leg_curl.jpg"),
+	CABLE_MACHINE("케이블 머신", "s3://your-bucket/cable_machine.jpg"),
+	DUMBBELLS("덤벨 세트", "s3://your-bucket/dumbbells.jpg"),
+	BARBELLS("바벨 세트", "s3://your-bucket/barbells.jpg"),
+	TREADMILL("러닝머신", "s3://your-bucket/treadmill.jpg");
+
+	private final String name;
+	private final String imageUrl;
+
+	GymMachine(String name, String imageUrl) {
+		this.name = name;
+		this.imageUrl = imageUrl;
+	}
+
+	// 중복 없이 랜덤 n개 선택
+	public static List<GymMachine> getRandomMachines(int count) {
+		List<GymMachine> machines = new ArrayList<>(Arrays.asList(values()));
+		Collections.shuffle(machines);
+		return machines.subList(0, Math.min(count, machines.size()));
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/machine/mapper/MachineMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/machine/mapper/MachineMapper.java
@@ -8,13 +8,15 @@ import org.helloworld.gymmate.domain.gym.machine.dto.MachineCreateRequest;
 import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
 import org.helloworld.gymmate.domain.gym.machine.entity.Machine;
 
-import jakarta.validation.Valid;
-
 public class MachineMapper {
-	public static Machine toEntity(@Valid MachineCreateRequest request, String imageUrl, Gym gym) {
+	public static Machine toEntity(MachineCreateRequest request, String imageUrl, Gym gym) {
+		return toEntity(request.machineName(), request.amount(), imageUrl, gym);
+	}
+
+	public static Machine toEntity(String machineName, Integer amount, String imageUrl, Gym gym) {
 		return Machine.builder()
-			.machineName(request.machineName())
-			.amount(request.amount())
+			.machineName(machineName)
+			.amount(amount)
 			.machineImage(imageUrl)
 			.gym(gym)
 			.build();


### PR DESCRIPTION
# 📝 제목
feat(gym) : 크롤링 데이터 수집 중 가짜 머신 정보 삽입

---

## 🔘 Part
- gym
 - machine
---

## 🔎 작업 내용
- 크롤링을 통해 기구정보 가져오기는 힘들것이라 판단해 보여주기용으로 가짜 머신정보 삽입했습니다.
- 아닌거같다싶으면 주석처리 해두면 될것같습니다.
- 작업예정 : s3에 이미지 업로드 후 enum url 값 수정

---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [ ] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
