### PR TITLE
feat(reservation) : 수강생의 예약조회 + 트레이너의 예약조회

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -10,6 +10,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -44,6 +45,7 @@ public class ReservationController {
 	 */
 	@PreAuthorize("hasRole('ROLE_MEMBER')")
 	@PostMapping("/ptProduct/{ptProductId}")
+	@Validated
 	public ResponseEntity<Long> register(
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@PathVariable Long ptProductId,

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -1,19 +1,26 @@
 package org.helloworld.gymmate.domain.reservation.controller;
 
+import org.helloworld.gymmate.common.dto.PageDto;
+import org.helloworld.gymmate.common.mapper.PageMapper;
 import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationResponse;
 import org.helloworld.gymmate.domain.reservation.service.ReservationService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 import jakarta.validation.Valid;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
 import lombok.RequiredArgsConstructor;
 
 @RestController
@@ -47,6 +54,27 @@ public class ReservationController {
 				customOAuth2User.getUserId(),
 				ptProductId,
 				request
+			));
+	}
+
+	/*
+	  멤버의 예약 목록 조회 API
+	  컨트롤러 -> 서비스 전달 정보 : 유저id
+	 */
+	@PreAuthorize("hasRole('ROLE_MEMBER')")
+	@GetMapping("/member")
+	public ResponseEntity<PageDto<ReservationResponse>> getReservations(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+		@RequestParam(defaultValue = "0") @Min(0) int page,
+		@RequestParam(defaultValue = "10") @Min(1) @Max(50) int pageSize
+	) {
+		return ResponseEntity.ok()
+			.body(PageMapper.toPageDto(
+				reservationService.getReservations(
+					customOAuth2User.getUserId(),
+					page,
+					pageSize
+				)
 			));
 	}
 

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/controller/ReservationController.java
@@ -63,14 +63,35 @@ public class ReservationController {
 	 */
 	@PreAuthorize("hasRole('ROLE_MEMBER')")
 	@GetMapping("/member")
-	public ResponseEntity<PageDto<ReservationResponse>> getReservations(
+	public ResponseEntity<PageDto<ReservationResponse>> getMemberReservations(
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
 		@RequestParam(defaultValue = "0") @Min(0) int page,
 		@RequestParam(defaultValue = "10") @Min(1) @Max(50) int pageSize
 	) {
 		return ResponseEntity.ok()
 			.body(PageMapper.toPageDto(
-				reservationService.getReservations(
+				reservationService.getMemberReservations(
+					customOAuth2User.getUserId(),
+					page,
+					pageSize
+				)
+			));
+	}
+
+	/*
+    트레이너의 예약 목록 조회 API
+    컨트롤러 -> 서비스 전달 정보 : 유저id
+   */
+	@PreAuthorize("hasRole('ROLE_TRAINER')")
+	@GetMapping("/trainer")
+	public ResponseEntity<PageDto<ReservationResponse>> getTrainerReservations(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+		@RequestParam(defaultValue = "0") @Min(0) int page,
+		@RequestParam(defaultValue = "10") @Min(1) @Max(50) int pageSize
+	) {
+		return ResponseEntity.ok()
+			.body(PageMapper.toPageDto(
+				reservationService.getTrainerReservations(
 					customOAuth2User.getUserId(),
 					page,
 					pageSize

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationRequest.java
@@ -4,15 +4,10 @@ import java.time.LocalDate;
 
 import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
-import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
-import jakarta.validation.constraints.Positive;
 
 public record ReservationRequest(
 	Long reservationId,
-
-	@NotBlank(message = "상품명은 필수입니다")
-	String productName,
 
 	@NotNull(message = "예약 날짜는 필수입니다")
 	LocalDate date,
@@ -21,10 +16,6 @@ public record ReservationRequest(
 	@Min(value = 0, message = "예약 시간은 0시 이상이어야 합니다")
 	@Max(value = 23, message = "예약 시간은 23시 이하여야 합니다")
 	Integer time,
-
-	@NotNull(message = "가격은 필수입니다")
-	@Positive(message = "가격은 0보다 커야 합니다")
-	Long price,
 
 	LocalDate cancelDate, // 예약 생성 시에는 필요 없음
 

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/dto/ReservationResponse.java
@@ -1,0 +1,15 @@
+package org.helloworld.gymmate.domain.reservation.dto;
+
+import java.time.LocalDate;
+
+public record ReservationResponse(
+	Long reservationId,
+	String productName,
+	LocalDate date,
+	Integer time,
+	Long price,
+	LocalDate cancelDate,
+	LocalDate completedDate,
+	Long trainerId
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/mapper/ReservationMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/mapper/ReservationMapper.java
@@ -2,6 +2,7 @@ package org.helloworld.gymmate.domain.reservation.mapper;
 
 import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
 import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationResponse;
 import org.helloworld.gymmate.domain.reservation.entity.Reservation;
 
 public class ReservationMapper {
@@ -23,5 +24,18 @@ public class ReservationMapper {
 			.price(ptProduct.getPtProductFee())        // 스냅샷
 			.memberId(userId)
 			.build();
+	}
+
+	public static ReservationResponse toDto(Reservation reservation) {
+		return new ReservationResponse(
+			reservation.getReservationId(),
+			reservation.getProductName(),
+			reservation.getDate(),
+			reservation.getTime(),
+			reservation.getPrice(),
+			reservation.getCancelDate(),
+			reservation.getCompletedDate(),
+			reservation.getTrainerId()
+		);
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/repository/ReservationRepository.java
@@ -9,4 +9,6 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
 	Page<Reservation> findByMemberId(Long memberId, Pageable pageable);
+
+	Page<Reservation> findByTrainerId(Long trainerId, Pageable pageable);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/repository/ReservationRepository.java
@@ -1,10 +1,12 @@
 package org.helloworld.gymmate.domain.reservation.repository;
 
 import org.helloworld.gymmate.domain.reservation.entity.Reservation;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface ReservationRepository extends JpaRepository<Reservation, Long> {
-
+	Page<Reservation> findByMemberId(Long memberId, Pageable pageable);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
@@ -46,7 +46,7 @@ public class ReservationService {
 	   - 리턴값 : 회원의 예약 목록
 	 */
 	@Transactional(readOnly = true)
-	public Page<ReservationResponse> getReservations(
+	public Page<ReservationResponse> getMemberReservations(
 		Long memberId,
 		int page,
 		int pageSize
@@ -59,6 +59,28 @@ public class ReservationService {
 
 		// 페이징된 데이터 조회 및 DTO 변환
 		return reservationRepository.findByMemberId(memberId, pageable)
+			.map(ReservationMapper::toDto);
+	}
+
+	/*
+	  회원의 예약 목록 조회 로직
+	   - 매개변수 : 회원 ID
+	   - 리턴값 : 회원의 예약 목록
+	 */
+	@Transactional(readOnly = true)
+	public Page<ReservationResponse> getTrainerReservations(
+		Long trainerId,
+		int page,
+		int pageSize
+	) {
+		// 정렬 조건 고정 (예약 날짜 내림차순)
+		Sort sort = Sort.by(Sort.Direction.DESC, "date");
+
+		// 페이징 요청 생성
+		Pageable pageable = PageRequest.of(page, pageSize, sort);
+
+		// 페이징된 데이터 조회 및 DTO 변환
+		return reservationRepository.findByTrainerId(trainerId, pageable)
 			.map(ReservationMapper::toDto);
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/reservation/service/ReservationService.java
@@ -3,9 +3,14 @@ package org.helloworld.gymmate.domain.reservation.service;
 import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
 import org.helloworld.gymmate.domain.pt.pt_product.service.PtProductService;
 import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationResponse;
 import org.helloworld.gymmate.domain.reservation.entity.Reservation;
 import org.helloworld.gymmate.domain.reservation.mapper.ReservationMapper;
 import org.helloworld.gymmate.domain.reservation.repository.ReservationRepository;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -33,5 +38,27 @@ public class ReservationService {
 
 		// 3) 저장 및 ID 반환
 		return reservationRepository.save(reservation).getReservationId();
+	}
+
+	/*
+	  회원의 예약 목록 조회 로직
+	   - 매개변수 : 회원 ID
+	   - 리턴값 : 회원의 예약 목록
+	 */
+	@Transactional(readOnly = true)
+	public Page<ReservationResponse> getReservations(
+		Long memberId,
+		int page,
+		int pageSize
+	) {
+		// 정렬 조건 고정 (예약 날짜 내림차순)
+		Sort sort = Sort.by(Sort.Direction.DESC, "date");
+
+		// 페이징 요청 생성
+		Pageable pageable = PageRequest.of(page, pageSize, sort);
+
+		// 페이징된 데이터 조회 및 DTO 변환
+		return reservationRepository.findByMemberId(memberId, pageable)
+			.map(ReservationMapper::toDto);
 	}
 }

--- a/src/test/java/org/helloworld/gymmate/reservation/service/ReservationServiceTest.java
+++ b/src/test/java/org/helloworld/gymmate/reservation/service/ReservationServiceTest.java
@@ -5,19 +5,27 @@ import static org.junit.jupiter.api.Assertions.*;
 import static org.mockito.Mockito.*;
 
 import java.time.LocalDate;
+import java.util.List;
 
 import org.helloworld.gymmate.domain.pt.pt_product.entity.PtProduct;
 import org.helloworld.gymmate.domain.pt.pt_product.service.PtProductService;
 import org.helloworld.gymmate.domain.reservation.dto.ReservationRequest;
+import org.helloworld.gymmate.domain.reservation.dto.ReservationResponse;
 import org.helloworld.gymmate.domain.reservation.entity.Reservation;
 import org.helloworld.gymmate.domain.reservation.repository.ReservationRepository;
 import org.helloworld.gymmate.domain.reservation.service.ReservationService;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
 
 import jakarta.persistence.EntityNotFoundException;
 
@@ -32,17 +40,46 @@ class ReservationServiceTest {
 	@Mock
 	private ReservationRepository reservationRepository;
 
+	private Long memberId;
+	private int page;
+	private int pageSize;
+	private Sort sort;
+	private List<Reservation> reservations;
+	private PageRequest pageRequest;
+
+	@BeforeEach
+	void setUp() {
+		// 공통으로 사용할 테스트 데이터 설정
+		memberId = 1L;
+		page = 0;
+		pageSize = 10;
+		sort = Sort.by(Sort.Direction.DESC, "date");
+		pageRequest = PageRequest.of(page, pageSize, sort);
+
+		// 테스트용 예약 데이터 생성
+		reservations = List.of(
+			createReservation(1L, "PT 상품1", LocalDate.now().plusDays(1), 14),
+			createReservation(2L, "PT 상품2", LocalDate.now(), 15),
+			createReservation(3L, "PT 상품3", LocalDate.now().minusDays(1), 16)
+		);
+	}
+
+	@AfterEach
+	void tearDown() {
+		// 필요한 경우 정리 작업 수행
+	}
+
 	@Test
-	@DisplayName("예약 생성 성공")
+	@DisplayName("예약 생성 - 성공")
 	void registerSuccess() {
 		// given
 		Long userId = 1L;
 		Long ptProductId = 1L;
 		ReservationRequest request = new ReservationRequest(
 			null,                   // reservationId
-			"PT 상품",              // productName
-			LocalDate.now().plusDays(1), // date (내일)
-			14,                     // time (14시)
+			"PT 상품1",             // productName
+			LocalDate.now().plusDays(1), // date
+			14,                     // time
 			100000L,               // price
 			null,                  // cancelDate
 			null                   // completedDate
@@ -50,7 +87,7 @@ class ReservationServiceTest {
 
 		PtProduct ptProduct = PtProduct.builder()
 			.ptProductId(ptProductId)
-			.ptProductName("PT 상품")
+			.ptProductName("PT 상품1")
 			.trainerId(2L)
 			.ptProductFee(100000L)
 			.build();
@@ -58,11 +95,11 @@ class ReservationServiceTest {
 		Reservation savedReservation = Reservation.builder()
 			.reservationId(1L)
 			.productName(ptProduct.getPtProductName())
-			.trainerId(ptProduct.getTrainerId())
 			.date(request.date())
 			.time(request.time())
 			.price(ptProduct.getPtProductFee())
 			.memberId(userId)
+			.trainerId(ptProduct.getTrainerId())
 			.build();
 
 		// when
@@ -72,19 +109,27 @@ class ReservationServiceTest {
 		Long result = reservationService.register(userId, ptProductId, request);
 
 		// then
-		assertThat(result).isEqualTo(savedReservation.getReservationId());
-		verify(ptProductService).findProductOrThrow(ptProductId);
-		verify(reservationRepository).save(any(Reservation.class));
+		assertAll(
+			() -> assertThat(result).isEqualTo(savedReservation.getReservationId()),
+			() -> verify(ptProductService).findProductOrThrow(ptProductId),
+			() -> verify(reservationRepository).save(any(Reservation.class))
+		);
 	}
 
 	@Test
-	@DisplayName("존재하지 않는 PT 상품으로 예약 시도 시 예외 발생")
+	@DisplayName("예약 생성 - PT 상품이 존재하지 않는 경우")
 	void registerWithNonExistentProduct() {
 		// given
 		Long userId = 1L;
 		Long ptProductId = 999L;
 		ReservationRequest request = new ReservationRequest(
-			null, "PT 상품", LocalDate.now().plusDays(1), 14, 100000L, null, null
+			null,
+			"존재하지 않는 상품",
+			LocalDate.now().plusDays(1),
+			14,
+			100000L,
+			null,
+			null
 		);
 
 		// when
@@ -95,5 +140,104 @@ class ReservationServiceTest {
 		assertThrows(EntityNotFoundException.class, () ->
 			reservationService.register(userId, ptProductId, request)
 		);
+		verify(ptProductService).findProductOrThrow(ptProductId);
+		verify(reservationRepository, never()).save(any(Reservation.class));
+	}
+	
+	@Test
+	@DisplayName("회원의 예약 목록 조회 - 성공")
+	void getReservationsSuccess() {
+		// given
+		Page<Reservation> reservationPage = new PageImpl<>(
+			reservations,
+			pageRequest,
+			reservations.size()
+		);
+
+		when(reservationRepository.findByMemberId(memberId, pageRequest))
+			.thenReturn(reservationPage);
+
+		// when
+		Page<ReservationResponse> result = reservationService.getReservations(
+			memberId,
+			page,
+			pageSize
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(result).isNotNull(),
+			() -> assertThat(result.getContent()).hasSize(3),
+			() -> assertThat(result.getContent().get(0).date())
+				.isAfter(result.getContent().get(1).date()),
+			() -> assertThat(result.getTotalElements()).isEqualTo(3),
+			() -> assertThat(result.getNumber()).isEqualTo(page),
+			() -> assertThat(result.getSize()).isEqualTo(pageSize)
+		);
+
+		verify(reservationRepository).findByMemberId(memberId, pageRequest);
+		verifyNoMoreInteractions(reservationRepository);
+	}
+
+	@Test
+	@DisplayName("회원의 예약 목록 조회 - 빈 결과")
+	void getReservationsEmpty() {
+		// given
+		Page<Reservation> emptyPage = new PageImpl<>(
+			List.of(),
+			pageRequest,
+			0
+		);
+
+		when(reservationRepository.findByMemberId(memberId, pageRequest))
+			.thenReturn(emptyPage);
+
+		// when
+		Page<ReservationResponse> result = reservationService.getReservations(
+			memberId,
+			page,
+			pageSize
+		);
+
+		// then
+		assertAll(
+			() -> assertThat(result).isNotNull(),
+			() -> assertThat(result.getContent()).isEmpty(),
+			() -> assertThat(result.getTotalElements()).isZero(),
+			() -> assertThat(result.getTotalPages()).isZero()
+		);
+
+		verify(reservationRepository).findByMemberId(memberId, pageRequest);
+		verifyNoMoreInteractions(reservationRepository);
+	}
+
+	// 테스트용 Reservation 객체 생성 헬퍼 메서드
+	private Reservation createReservation(
+		Long id,
+		String productName,
+		LocalDate date,
+		Integer time
+	) {
+		return Reservation.builder()
+			.reservationId(id)
+			.productName(productName)
+			.date(date)
+			.time(time)
+			.price(100000L)
+			.memberId(memberId)
+			.trainerId(1L)
+			.build();
+	}
+
+	private Reservation createTestReservation(Long id, String productName, LocalDate date) {
+		return Reservation.builder()
+			.reservationId(id)
+			.productName(productName)
+			.date(date)
+			.time(14)
+			.price(100000L)
+			.memberId(memberId)
+			.trainerId(1L)
+			.build();
 	}
 }


### PR DESCRIPTION
## 📝 제목
feat(reservation) : 수강생의 예약조회 + 트레이너의 예약조회


## 🔘 Part
- reservation

## 🔎 작업 내용
- **수강생의 PT예약 조회** : 로그인한 member id를 통해 예약 내역 확인
- **멤버의 PT예약 조회** : 로그인한 trainer id를 통해 예약 내역 확인
- **레포지터리** : memberId로 예약내역 확인 함수, trainerId로 예약 내역 확인 함수 추가


## 🖼️ 이미지 첨부
<img width="777" alt="member" src="https://github.com/user-attachments/assets/b214173c-149b-469e-b82e-75770a2e9bc7" />
<img width="783" alt="trainer" src="https://github.com/user-attachments/assets/3aaec9af-5c6c-4c4c-8a50-5d6d5897d8f5" />





## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

## ➕ 이슈 링크
- [GYMMATE-187](https://dia19.atlassian.net/browse/GYMMATE-187)


[GYMMATE-187]: https://dia19.atlassian.net/browse/GYMMATE-187?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ