### PR TITLE
refactor(gym): 대규모 - 파트너 헬스장 분리

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
@@ -1,94 +1,27 @@
 package org.helloworld.gymmate.domain.gym.gymInfo.controller;
 
-import java.util.List;
-import java.util.Map;
-
-import org.helloworld.gymmate.common.validate.custom.ValidImageFile;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
 import org.helloworld.gymmate.domain.gym.gymInfo.service.GymService;
 import org.helloworld.gymmate.domain.gym.machine.dto.FacilityAndMachineResponse;
-import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
-import org.helloworld.gymmate.domain.gym.machine.service.MachineService;
-import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
-import org.springframework.http.HttpStatus;
-import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.access.prepost.PreAuthorize;
-import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestPart;
 import org.springframework.web.bind.annotation.RestController;
-import org.springframework.web.multipart.MultipartFile;
 
-import jakarta.validation.Valid;
+import io.swagger.v3.oas.annotations.tags.Tag;
 import lombok.RequiredArgsConstructor;
 
+@Tag(name = "헬스장 API", description = "헬스장 지도 페이지")
 @RestController
 @RequestMapping("/gym")
 @RequiredArgsConstructor
 public class GymController {
-
 	private final GymService gymService;
-	private final MachineService machineService;
-
-	// 제휴 헬스장 등록
-	@PreAuthorize("hasRole('ROLE_TRAINER')")
-	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<Map<String, Long>> registerPartnerGym(
-		@RequestPart("request") @Valid RegisterGymRequest request,
-		@RequestPart(value = "images", required = false) @ValidImageFile List<MultipartFile> images,
-		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-
-		Long partnerGymId = gymService.registerPartnerGym(request, images, customOAuth2User.getUserId());
-		return ResponseEntity.status(HttpStatus.CREATED)
-			.body(Map.of("partnerGymId", partnerGymId));
-
-	}
-
-	// 제휴 헬스장 수정
-	@PreAuthorize("hasRole('ROLE_TRAINER')")
-	@PutMapping(value = "/partnerGym/{partnerGymId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<Long> updatePartnerGym(
-		@PathVariable Long partnerGymId,
-		@RequestPart("request") @Valid UpdateGymRequest request,
-		@RequestPart(value = "images", required = false) @ValidImageFile List<MultipartFile> images,
-		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-
-		return ResponseEntity.ok(
-			gymService.updatePartnerGym(partnerGymId, request, images, customOAuth2User.getUserId()));
-	}
-
-	// 제휴 헬스장 조회
-	@PreAuthorize("hasRole('ROLE_TRAINER')")
-	@GetMapping("/partnerGym/{partnerGymId}")
-	public ResponseEntity<PartnerGymDetailResponse> getPartnerGymDetail(
-		@PathVariable Long partnerGymId,
-		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
-	) {
-		return ResponseEntity.ok(
-			gymService.getPartnerGymDetail(partnerGymId, customOAuth2User.getUserId()));
-
-	}
-
-	// 제휴 헬스장 머신 리스트 조회
-	@PreAuthorize("hasRole('ROLE_TRAINER')")
-	@GetMapping("/machine")
-	public ResponseEntity<List<MachineResponse>> getMachines(
-		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
-
-		return ResponseEntity.ok(machineService.getOwnMachines(customOAuth2User.getUserId()));
-	}
 
 	@GetMapping("/{gymId}/facility")
 	public ResponseEntity<FacilityAndMachineResponse> getFacilitiesAndMachines(
 		@PathVariable Long gymId
 	) {
-		return ResponseEntity.ok(machineService.getOwnFacilitiesAndMachines(gymId));
+		return ResponseEntity.ok(gymService.getOwnFacilitiesAndMachines(gymId));
 	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
@@ -6,6 +6,7 @@ import java.util.Map;
 import org.helloworld.gymmate.common.validate.custom.ValidImageFile;
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
 import org.helloworld.gymmate.domain.gym.gymInfo.service.GymService;
 import org.helloworld.gymmate.domain.gym.machine.dto.FacilityAndMachineResponse;
 import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
@@ -53,18 +54,27 @@ public class GymController {
 	// 제휴 헬스장 수정
 	@PreAuthorize("hasRole('ROLE_TRAINER')")
 	@PutMapping(value = "/partnerGym/{partnerGymId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<Map<String, Long>> updatePartnerGym(
+	public ResponseEntity<Long> updatePartnerGym(
+		@PathVariable Long partnerGymId,
 		@RequestPart("request") @Valid UpdateGymRequest request,
 		@RequestPart(value = "images", required = false) @ValidImageFile List<MultipartFile> images,
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 
-		Long partnerGymId = gymService.updatePartnerGym(request, images, customOAuth2User.getUserId());
-
-		return ResponseEntity.status(HttpStatus.OK)
-			.body(Map.of("partnerGymId(modified)", partnerGymId));
+		return ResponseEntity.ok(
+			gymService.updatePartnerGym(partnerGymId, request, images, customOAuth2User.getUserId()));
 	}
 
-	// 제휴 헬스장 조회 > gymProductId, partnerGymId, reuqest, image,
+	// 제휴 헬스장 조회
+	@PreAuthorize("hasRole('ROLE_TRAINER')")
+	@GetMapping("/partnerGym/{partnerGymId}")
+	public ResponseEntity<PartnerGymDetailResponse> getPartnerGymDetail(
+		@PathVariable Long partnerGymId,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
+	) {
+		return ResponseEntity.ok(
+			gymService.getPartnerGymDetail(partnerGymId, customOAuth2User.getUserId()));
+
+	}
 
 	// 제휴 헬스장 머신 리스트 조회
 	@PreAuthorize("hasRole('ROLE_TRAINER')")

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/controller/GymController.java
@@ -53,15 +53,18 @@ public class GymController {
 	// 제휴 헬스장 수정
 	@PreAuthorize("hasRole('ROLE_TRAINER')")
 	@PutMapping(value = "/partnerGym/{partnerGymId}", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
-	public ResponseEntity<Long> updatePartnerGym(
-		@PathVariable Long partnerGymId,
+	public ResponseEntity<Map<String, Long>> updatePartnerGym(
 		@RequestPart("request") @Valid UpdateGymRequest request,
 		@RequestPart(value = "images", required = false) @ValidImageFile List<MultipartFile> images,
 		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
 
-		return ResponseEntity.ok(
-			gymService.updatePartnerGym(partnerGymId, request, images, customOAuth2User.getUserId()));
+		Long partnerGymId = gymService.updatePartnerGym(request, images, customOAuth2User.getUserId());
+
+		return ResponseEntity.status(HttpStatus.OK)
+			.body(Map.of("partnerGymId(modified)", partnerGymId));
 	}
+
+	// 제휴 헬스장 조회 > gymProductId, partnerGymId, reuqest, image,
 
 	// 제휴 헬스장 머신 리스트 조회
 	@PreAuthorize("hasRole('ROLE_TRAINER')")

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/RegisterGymRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/RegisterGymRequest.java
@@ -7,7 +7,6 @@ import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
 public record RegisterGymRequest(
 	Long gymId,
 	GymInfoRequest gymInfoRequest,
-	List<GymProductRequest> gymProductRequest,
-	List<String> imageUrl
+	List<GymProductRequest> gymProductRequest
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/UpdateGymRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/UpdateGymRequest.java
@@ -5,9 +5,9 @@ import java.util.List;
 import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
 
 public record UpdateGymRequest(
-	Long partnerGymId,
 	GymInfoRequest gymInfoRequest,
 	List<GymProductRequest> gymProductRequest,
+	//TODO: List<GymProductRequest> deleteGymProductRequest
 	List<Long> deleteImageIds
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/UpdateGymRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/request/UpdateGymRequest.java
@@ -2,8 +2,12 @@ package org.helloworld.gymmate.domain.gym.gymInfo.dto.request;
 
 import java.util.List;
 
+import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
+
 public record UpdateGymRequest(
+	Long partnerGymId,
 	GymInfoRequest gymInfoRequest,
+	List<GymProductRequest> gymProductRequest,
 	List<Long> deleteImageIds
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/GymImageResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/GymImageResponse.java
@@ -1,0 +1,7 @@
+package org.helloworld.gymmate.domain.gym.gymInfo.dto.response;
+
+public record GymImageResponse(
+	Long imageId,
+	String url
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/GymInfoResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/GymInfoResponse.java
@@ -1,0 +1,11 @@
+package org.helloworld.gymmate.domain.gym.gymInfo.dto.response;
+
+import org.helloworld.gymmate.domain.gym.facility.dto.FacilityResponse;
+
+public record GymInfoResponse(
+	String startTime,
+	String endTime,
+	String intro,
+	FacilityResponse facility
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/GymProductResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/GymProductResponse.java
@@ -1,0 +1,8 @@
+package org.helloworld.gymmate.domain.gym.gymInfo.dto.response;
+
+public record GymProductResponse(
+	Long gymProductId,
+	Integer gymProductMonth,
+	Integer gymProductFee
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/PartnerGymDetailResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/dto/response/PartnerGymDetailResponse.java
@@ -1,0 +1,11 @@
+package org.helloworld.gymmate.domain.gym.gymInfo.dto.response;
+
+import java.util.List;
+
+public record PartnerGymDetailResponse(
+	Long partnerGymId,
+	GymInfoResponse gymInfo,
+	List<GymProductResponse> gymProducts,
+	List<GymImageResponse> images
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/Gym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/Gym.java
@@ -5,6 +5,7 @@ import java.util.List;
 
 import org.helloworld.gymmate.domain.gym.facility.entity.Facility;
 import org.helloworld.gymmate.domain.gym.machine.entity.Machine;
+import org.hibernate.annotations.BatchSize;
 import org.locationtech.jts.geom.Point;
 
 import jakarta.persistence.CascadeType;
@@ -69,6 +70,7 @@ public class Gym {
 	private String placeUrl;
 
 	@OneToMany(mappedBy = "gym", cascade = CascadeType.ALL, orphanRemoval = true)
+	@BatchSize(size = 20)
 	@Builder.Default
 	private List<GymImage> images = new ArrayList<>();  //이미지의 경우 default이미지 표시
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/entity/PartnerGym.java
@@ -4,6 +4,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+import org.hibernate.annotations.BatchSize;
 
 import jakarta.persistence.CascadeType;
 import jakarta.persistence.Column;
@@ -43,6 +44,7 @@ public class PartnerGym {
 	private Gym gym;
 
 	@OneToMany(mappedBy = "partnerGym", cascade = CascadeType.ALL, orphanRemoval = true)
+	@BatchSize(size = 20)
 	@Builder.Default
 	private List<GymProduct> gymProducts = new ArrayList<>();
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/mapper/PartnerGymMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/mapper/PartnerGymMapper.java
@@ -1,0 +1,60 @@
+package org.helloworld.gymmate.domain.gym.gymInfo.mapper;
+
+import java.util.List;
+
+import org.helloworld.gymmate.domain.gym.facility.mapper.FacilityMapper;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.GymImageResponse;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.GymInfoResponse;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.GymProductResponse;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.GymImage;
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
+import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+
+public class PartnerGymMapper {
+
+	public static PartnerGymDetailResponse toDto(PartnerGym partnerGym) {
+		Gym gym = partnerGym.getGym();
+
+		List<GymProductResponse> gymProductResponses = partnerGym.getGymProducts().stream()
+			.map(PartnerGymMapper::toGymProductDto)
+			.toList();
+
+		List<GymImageResponse> gymImageResponses = gym.getImages().stream()
+			.map(PartnerGymMapper::toDto)
+			.toList();
+
+		return new PartnerGymDetailResponse(
+			partnerGym.getPartnerGymId(),
+			toGymInfoDto(gym),
+			gymProductResponses,
+			gymImageResponses
+		);
+
+	}
+
+	private static GymInfoResponse toGymInfoDto(Gym gym) {
+		return new GymInfoResponse(
+			gym.getStartTime(),
+			gym.getEndTime(),
+			gym.getIntro(),
+			FacilityMapper.toDto(gym.getFacility())
+		);
+	}
+
+	private static GymProductResponse toGymProductDto(GymProduct product) {
+		return new GymProductResponse(
+			product.getGymProductId(),
+			product.getGymProductMonth(),
+			product.getGymProductFee()
+		);
+	}
+
+	public static GymImageResponse toDto(GymImage gymImage) {
+		return new GymImageResponse(
+			gymImage.getId(),
+			gymImage.getUrl()
+		);
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/repository/PartnerGymRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/repository/PartnerGymRepository.java
@@ -1,10 +1,21 @@
 package org.helloworld.gymmate.domain.gym.gymInfo.repository;
 
+import java.util.Optional;
+
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 public interface PartnerGymRepository extends JpaRepository<PartnerGym, Long> {
 
 	boolean existsByOwnerIdAndGym_GymId(Long ownerId, Long gymId);
 
+	@Query("""
+			SELECT DISTINCT pg FROM PartnerGym pg
+			JOIN FETCH pg.gym g
+			LEFT JOIN FETCH g.facility
+			WHERE pg.partnerGymId = :partnerGymId
+		""")
+	Optional<PartnerGym> findByIdWithGymAndProducts(@Param("partnerGymId") Long partnerGymId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
@@ -12,10 +12,12 @@ import org.helloworld.gymmate.domain.gym.facility.mapper.FacilityMapper;
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.GymInfoRequest;
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.GymImage;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymInfo.mapper.GymMapper;
+import org.helloworld.gymmate.domain.gym.gymInfo.mapper.PartnerGymMapper;
 import org.helloworld.gymmate.domain.gym.gymInfo.repository.GymRepository;
 import org.helloworld.gymmate.domain.gym.gymInfo.repository.PartnerGymRepository;
 import org.helloworld.gymmate.domain.gym.gymProduct.service.GymProductService;
@@ -88,7 +90,7 @@ public class GymService {
 	}
 
 	@Transactional
-	public Long updatePartnerGym(UpdateGymRequest request, List<MultipartFile> images,
+	public Long updatePartnerGym(Long partnerGymId, UpdateGymRequest request, List<MultipartFile> images,
 		Long ownerId) {
 		// 운영자 맞는지 확인
 		Trainer owner = findByOwnerId(ownerId);
@@ -97,7 +99,7 @@ public class GymService {
 		}
 
 		// partnerGymId로 Gym 가져오기
-		Gym existingGym = getGymByPartnerGymId(request.partnerGymId());
+		Gym existingGym = getGymByPartnerGymId(partnerGymId);
 
 		// gym 업데이트
 		GymMapper.updateEntity(existingGym, request.gymInfoRequest().gymRequest());
@@ -110,7 +112,28 @@ public class GymService {
 
 		// gymProduct 업데이트
 
-		return request.partnerGymId();
+		return partnerGymId;
+	}
+
+	// 제휴 헬스장 조회
+	@Transactional(readOnly = true)
+	public PartnerGymDetailResponse getPartnerGymDetail(Long partnerGymId, Long ownerId) {
+
+		PartnerGym partnerGym = partnerGymRepository.findByIdWithGymAndProducts(partnerGymId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_GYM_NOT_FOUND));
+
+		// 운영자 맞는지 확인
+		Trainer owner = findByOwnerId(ownerId);
+		if (!owner.getIsOwner()) {
+			throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
+		}
+
+		// Lazy 로딩 유도 (실제 접근 시 쿼리 발생)
+		partnerGym.getGym().getImages().size();
+		partnerGym.getGymProducts().size();
+
+		return PartnerGymMapper.toDto(partnerGym);
+
 	}
 
 	// 가까운 헬스장 조회
@@ -187,6 +210,7 @@ public class GymService {
 		Facility facility = existingGym.getFacility();
 		facility.update(request.facilityRequest());
 	}
+
 }
 
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
@@ -88,7 +88,7 @@ public class GymService {
 	}
 
 	@Transactional
-	public Long updatePartnerGym(Long partnerGymId, UpdateGymRequest request, List<MultipartFile> images,
+	public Long updatePartnerGym(UpdateGymRequest request, List<MultipartFile> images,
 		Long ownerId) {
 		// 운영자 맞는지 확인
 		Trainer owner = findByOwnerId(ownerId);
@@ -97,7 +97,7 @@ public class GymService {
 		}
 
 		// partnerGymId로 Gym 가져오기
-		Gym existingGym = getGymByPartnerGymId(partnerGymId);
+		Gym existingGym = getGymByPartnerGymId(request.partnerGymId());
 
 		// gym 업데이트
 		GymMapper.updateEntity(existingGym, request.gymInfoRequest().gymRequest());
@@ -109,9 +109,8 @@ public class GymService {
 		updateImages(request, images, existingGym);
 
 		// gymProduct 업데이트
-		//TODO: 메소드 호출
 
-		return partnerGymId;
+		return request.partnerGymId();
 	}
 
 	// 가까운 헬스장 조회

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymInfo/service/GymService.java
@@ -4,42 +4,30 @@ import java.util.List;
 
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
-import org.helloworld.gymmate.common.s3.FileManager;
-import org.helloworld.gymmate.common.util.StringUtil;
 import org.helloworld.gymmate.domain.gym.facility.dto.FacilityResponse;
-import org.helloworld.gymmate.domain.gym.facility.entity.Facility;
 import org.helloworld.gymmate.domain.gym.facility.mapper.FacilityMapper;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.GymInfoRequest;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
-import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.GymImage;
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
-import org.helloworld.gymmate.domain.gym.gymInfo.mapper.GymMapper;
-import org.helloworld.gymmate.domain.gym.gymInfo.mapper.PartnerGymMapper;
 import org.helloworld.gymmate.domain.gym.gymInfo.repository.GymRepository;
-import org.helloworld.gymmate.domain.gym.gymInfo.repository.PartnerGymRepository;
-import org.helloworld.gymmate.domain.gym.gymProduct.service.GymProductService;
-import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
-import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
-import org.helloworld.gymmate.domain.user.trainer.service.TrainerService;
+import org.helloworld.gymmate.domain.gym.machine.dto.FacilityAndMachineResponse;
+import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
+import org.helloworld.gymmate.domain.gym.machine.mapper.MachineMapper;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-import org.springframework.web.multipart.MultipartFile;
 
 import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class GymService {
-
-	private final PartnerGymRepository partnerGymRepository;
 	private final GymRepository gymRepository;
-	private final FileManager fileManager;
-	private final TrainerRepository trainerRepository;
-	private final GymProductService gymProductService;
-	private final TrainerService trainerService;
+
+	@Transactional(readOnly = true)
+	public FacilityAndMachineResponse getOwnFacilitiesAndMachines(Long gymId) {
+		Gym gym = getExistingGym(gymId);
+		FacilityResponse facilityResponse = getFacility(gym);
+		List<MachineResponse> machineResponses = MachineMapper.toDtoList(gym.getMachines());
+		return new FacilityAndMachineResponse(facilityResponse, machineResponses);
+	}
 
 	// 헬스장 조회
 	public Gym getExistingGym(Long gymId) {
@@ -47,171 +35,10 @@ public class GymService {
 			.orElseThrow(() -> new BusinessException(ErrorCode.GYM_NOT_FOUND));
 	}
 
-	//파트너헬스장 조회
-	public Gym getGymByPartnerGymId(Long partnerGymId) {
-		PartnerGym partnerGym = partnerGymRepository.findById(partnerGymId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_GYM_NOT_FOUND));
-
-		return partnerGym.getGym();
-	}
-
-	@Transactional
-	public Long registerPartnerGym(RegisterGymRequest request, List<MultipartFile> images, Long ownerId) {
-		// 운영자 맞는지 확인
-		Trainer owner = trainerService.findByUserId(ownerId);
-		if (!owner.getIsOwner()) {
-			throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
-		}
-
-		// 중복 등록 방지
-		if (partnerGymRepository.existsByOwnerIdAndGym_GymId(ownerId, request.gymId())) {
-			throw new BusinessException(ErrorCode.GYM_ALREADY_EXISTS);
-		}
-
-		// gym 있는지 확인
-		Gym existingGym = getExistingGym(request.gymId());
-
-		// gym 업데이트
-		GymMapper.updateEntity(existingGym, request.gymInfoRequest().gymRequest());
-
-		// facility 업데이트
-		updateFacility(existingGym, request.gymInfoRequest());
-
-		// gymImage 업데이트
-		saveImages(images, existingGym);
-
-		// partnerGym 저장
-		PartnerGym partnerGym = createPartnerGym(ownerId, existingGym);
-
-		//gymProduct 업데이트
-		gymProductService.registerGymProducts(request.gymProductRequest(), partnerGym);
-
-		return partnerGym.getPartnerGymId();
-	}
-
-	@Transactional
-	public Long updatePartnerGym(Long partnerGymId, UpdateGymRequest request, List<MultipartFile> images,
-		Long ownerId) {
-		// 운영자 맞는지 확인
-		Trainer owner = findByOwnerId(ownerId);
-		if (!owner.getIsOwner()) {
-			throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
-		}
-
-		// partnerGymId로 Gym 가져오기
-		Gym existingGym = getGymByPartnerGymId(partnerGymId);
-
-		// gym 업데이트
-		GymMapper.updateEntity(existingGym, request.gymInfoRequest().gymRequest());
-
-		// facility 업데이트
-		updateFacility(existingGym, request.gymInfoRequest());
-
-		// gymImage 업데이트
-		updateImages(request, images, existingGym);
-
-		// gymProduct 업데이트
-
-		return partnerGymId;
-	}
-
-	// 제휴 헬스장 조회
-	@Transactional(readOnly = true)
-	public PartnerGymDetailResponse getPartnerGymDetail(Long partnerGymId, Long ownerId) {
-
-		PartnerGym partnerGym = partnerGymRepository.findByIdWithGymAndProducts(partnerGymId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_GYM_NOT_FOUND));
-
-		// 운영자 맞는지 확인
-		Trainer owner = findByOwnerId(ownerId);
-		if (!owner.getIsOwner()) {
-			throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
-		}
-
-		// Lazy 로딩 유도 (실제 접근 시 쿼리 발생)
-		partnerGym.getGym().getImages().size();
-		partnerGym.getGymProducts().size();
-
-		return PartnerGymMapper.toDto(partnerGym);
-
-	}
-
-	// 가까운 헬스장 조회
-	@Transactional(readOnly = true)
-	public List<Gym> findNearbyGyms(double longitude, double latitude, double radiusInMeters, int limit) {
-		String point = StringUtil.format("POINT({} {})", latitude, longitude);
-		return gymRepository.findNearbyGyms(point, radiusInMeters, limit);
-	}
-
-	private PartnerGym createPartnerGym(Long ownerId, Gym gym) {
-		PartnerGym partnerGym = PartnerGym.builder()
-			.ownerId(ownerId)
-			.gym(gym)
-			.build();
-
-		return partnerGymRepository.save(partnerGym);
-	}
-
 	// 편의시설 조회
 	@Transactional(readOnly = true)
 	public FacilityResponse getFacility(Gym gym) {
 		return FacilityMapper.toDto(gym.getFacility());
 	}
-
-	private List<GymImage> uploadAndMapImages(List<MultipartFile> images, String tableName) {
-		if (images == null || images.isEmpty())
-			return List.of();
-
-		List<String> imageUrls;
-		try {
-			imageUrls = fileManager.uploadFiles(images, tableName);
-		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
-		}
-
-		return imageUrls.stream()
-			.map(url -> GymImage.builder().url(url).build())
-			.toList();
-	}
-
-	// 신규 이미지 저장
-	private void saveImages(List<MultipartFile> images, Gym gym) {
-		List<GymImage> gymImages = uploadAndMapImages(images, "gym");
-		gym.addImages(gymImages);
-	}
-
-	// 이미지 삭제 + 새 이미지 등록
-	private void updateImages(UpdateGymRequest request, List<MultipartFile> images, Gym gym) {
-		// 삭제할 이미지 ID 목록
-		List<Long> deleteImageIds = request.deleteImageIds() != null ? request.deleteImageIds() : List.of();
-
-		// 삭제할 이미지 필터링
-		List<GymImage> imagesToDelete = gym.getImages().stream()
-			.filter(img -> deleteImageIds.contains(img.getId()))
-			.toList();
-
-		// S3 + 연관관계 제거
-		for (GymImage image : imagesToDelete) {
-			fileManager.deleteFile(image.getUrl());
-			gym.removeImage(image);
-		}
-
-		// 새 이미지 업로드 및 등록
-		List<GymImage> newImages = uploadAndMapImages(images, "gym");
-		gym.addImages(newImages);
-	}
-
-	private Trainer findByOwnerId(Long ownerId) {
-		return trainerRepository.findByTrainerId(ownerId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
-	}
-
-	private void updateFacility(Gym existingGym, GymInfoRequest request) {
-		Facility facility = existingGym.getFacility();
-		facility.update(request.facilityRequest());
-	}
-
+	
 }
-
-
-

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
@@ -1,6 +1,7 @@
 package org.helloworld.gymmate.domain.gym.gymProduct.entity;
 
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
+import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
@@ -42,4 +43,10 @@ public class GymProduct {
 	@ManyToOne(fetch = FetchType.LAZY)
 	@JoinColumn(name = "partner_gym_id")
 	private PartnerGym partnerGym;
+
+	public void update(GymProductRequest request) {
+		this.gymProductFee = request.gymProductFee();
+		this.gymProductMonth = request.gymProductMonth();
+	}
+
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/entity/GymProduct.java
@@ -1,7 +1,7 @@
 package org.helloworld.gymmate.domain.gym.gymProduct.entity;
 
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/mapper/GymProductMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/mapper/GymProductMapper.java
@@ -1,8 +1,8 @@
 package org.helloworld.gymmate.domain.gym.gymProduct.mapper;
 
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
 
 import jakarta.validation.Valid;
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/repository/GymProductRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/repository/GymProductRepository.java
@@ -1,9 +1,14 @@
 package org.helloworld.gymmate.domain.gym.gymProduct.repository;
 
+import java.util.List;
+
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface GymProductRepository extends JpaRepository<GymProduct, Long> {
+
+	List<GymProduct> findByPartnerGym(PartnerGym partnerGym);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/repository/GymProductRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/repository/GymProductRepository.java
@@ -2,8 +2,8 @@ package org.helloworld.gymmate.domain.gym.gymProduct.repository;
 
 import java.util.List;
 
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/service/GymProductService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/service/GymProductService.java
@@ -2,11 +2,11 @@ package org.helloworld.gymmate.domain.gym.gymProduct.service;
 
 import java.util.List;
 
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.dto.GymProductRequest;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
 import org.helloworld.gymmate.domain.gym.gymProduct.mapper.GymProductMapper;
 import org.helloworld.gymmate.domain.gym.gymProduct.repository.GymProductRepository;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
 import org.springframework.stereotype.Service;
 
 import lombok.RequiredArgsConstructor;
@@ -18,7 +18,7 @@ public class GymProductService {
 	private final GymProductRepository gymProductRepository;
 
 	// 헬스장 이용권 정보 등록
-	public void registerGymProducts(List<GymProductRequest> requests, PartnerGym partnerGym) {
+	public void updateGymProducts(List<GymProductRequest> requests, PartnerGym partnerGym) {
 		List<GymProduct> gymProducts = requests.stream()
 			.map(request -> GymProductMapper.toEntity(request, partnerGym))
 			.toList();

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/service/GymProductService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymProduct/service/GymProductService.java
@@ -17,6 +17,7 @@ public class GymProductService {
 
 	private final GymProductRepository gymProductRepository;
 
+	// 헬스장 이용권 정보 등록
 	public void registerGymProducts(List<GymProductRequest> requests, PartnerGym partnerGym) {
 		List<GymProduct> gymProducts = requests.stream()
 			.map(request -> GymProductMapper.toEntity(request, partnerGym))
@@ -24,5 +25,40 @@ public class GymProductService {
 
 		gymProductRepository.saveAll(gymProducts);
 	}
+
+	// 헬스장 이용권 정보 수정
+	// @Transactional
+	// public void updateGymProducts(List<GymProductRequest> requests, PartnerGym partnerGym) {
+	// 	// 기존 이용권들 조회
+	// 	List<GymProduct> existingProducts = gymProductRepository.findByPartnerGym(partnerGym);
+	//
+	// 	// ID 기준으로 매핑
+	// 	Map<Long, GymProduct> existingMap = existingProducts.stream()
+	// 		.collect(Collectors.toMap(GymProduct::getGymProductId, Function.identity()));
+	//
+	// 	List<GymProduct> productsToSave = new ArrayList<>();
+	//
+	// 	for (GymProductRequest request : requests) {
+	// 		if (request.gymProductId() == null) {
+	// 			// 새로 추가되는 이용권
+	// 			GymProduct newProduct = GymProductMapper.toEntity(request, partnerGym);
+	// 			productsToSave.add(newProduct);
+	// 		} else {
+	// 			// 기존 이용권 수정
+	// 			GymProduct existing = existingMap.remove(request.gymProductId());
+	// 			existing.update(request); // 엔티티 내부 update 메서드
+	// 			productsToSave.add(existing);
+	// 		}
+	// 	}
+	//
+	// 	// 기존 목록 중 남은 것들은 요청에 없던 것 → 삭제 대상
+	// 	// TODO: 헬스장 이용권 정보 삭제 메서드 호출
+	//
+	// 	// 저장
+	// 	gymProductRepository.saveAll(productsToSave);
+	// }
+
+	// 헬스장 이용권 정보 삭제
+	//TODO: 메서드 작성(GYMMATE-190)
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/machine/service/MachineService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/machine/service/MachineService.java
@@ -5,15 +5,13 @@ import java.util.List;
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
 import org.helloworld.gymmate.common.s3.FileManager;
-import org.helloworld.gymmate.domain.gym.facility.dto.FacilityResponse;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
-import org.helloworld.gymmate.domain.gym.gymInfo.service.GymService;
-import org.helloworld.gymmate.domain.gym.machine.dto.FacilityAndMachineResponse;
 import org.helloworld.gymmate.domain.gym.machine.dto.MachineRequest;
 import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
 import org.helloworld.gymmate.domain.gym.machine.entity.Machine;
 import org.helloworld.gymmate.domain.gym.machine.mapper.MachineMapper;
 import org.helloworld.gymmate.domain.gym.machine.repository.MachineRepository;
+import org.helloworld.gymmate.domain.gym.partnerGym.service.PartnerGymService;
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.domain.user.trainer.service.TrainerService;
 import org.springframework.stereotype.Service;
@@ -29,7 +27,7 @@ public class MachineService {
 	private final TrainerService trainerService;
 	private final FileManager fileManager;
 	private final MachineRepository machineRepository;
-	private final GymService gymService;
+	private final PartnerGymService partnerGymService;
 
 	private final int MACHINE_MAX_SIZE = 30;
 
@@ -78,14 +76,6 @@ public class MachineService {
 	public List<MachineResponse> getOwnMachines(Long trainerId) {
 		Trainer trainer = ownerCheck(trainerId);
 		return MachineMapper.toDtoList(trainer.getGym().getMachines());
-	}
-
-	@Transactional(readOnly = true)
-	public FacilityAndMachineResponse getOwnFacilitiesAndMachines(Long gymId) {
-		Gym gym = gymService.getExistingGym(gymId);
-		FacilityResponse facilityResponse = gymService.getFacility(gym);
-		List<MachineResponse> machineResponses = MachineMapper.toDtoList(gym.getMachines());
-		return new FacilityAndMachineResponse(facilityResponse, machineResponses);
 	}
 
 	@Transactional

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/controller/PartnerGymController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/controller/PartnerGymController.java
@@ -1,0 +1,84 @@
+package org.helloworld.gymmate.domain.gym.partnerGym.controller;
+
+import java.util.List;
+import java.util.Map;
+
+import org.helloworld.gymmate.common.validate.custom.ValidImageFile;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
+import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
+import org.helloworld.gymmate.domain.gym.machine.service.MachineService;
+import org.helloworld.gymmate.domain.gym.partnerGym.service.PartnerGymService;
+import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestPart;
+import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.multipart.MultipartFile;
+
+import io.swagger.v3.oas.annotations.tags.Tag;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+
+@Tag(name = "제휴 헬스장 API", description = "헬스장 운영자 마이페이지")
+@RestController
+@RequestMapping("/partnergym")
+@RequiredArgsConstructor
+public class PartnerGymController {
+
+	private final PartnerGymService partnerGymService;
+	private final MachineService machineService;
+
+	// 제휴 헬스장 등록
+	@PreAuthorize("hasRole('ROLE_TRAINER')")
+	@PostMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<Map<String, Long>> registerPartnerGym(
+		@RequestPart("request") @Valid RegisterGymRequest request,
+		@RequestPart(value = "images", required = false) @ValidImageFile List<MultipartFile> images,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+		Long partnerGymId = partnerGymService.registerPartnerGym(request, images, customOAuth2User.getUserId());
+		return ResponseEntity.status(HttpStatus.CREATED)
+			.body(Map.of("partnerGymId", partnerGymId));
+
+	}
+
+	// 제휴 헬스장 수정
+	@PreAuthorize("hasRole('ROLE_TRAINER')")
+	@PutMapping(consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+	public ResponseEntity<Long> updatePartnerGym(
+		@RequestPart("request") @Valid UpdateGymRequest request,
+		@RequestPart(value = "images", required = false) @ValidImageFile List<MultipartFile> images,
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+		return ResponseEntity.ok(
+			partnerGymService.updatePartnerGym(request, images, customOAuth2User.getUserId()));
+	}
+
+	// 제휴 헬스장 조회
+	@PreAuthorize("hasRole('ROLE_TRAINER')")
+	@GetMapping
+	public ResponseEntity<PartnerGymDetailResponse> getPartnerGymDetail(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User
+	) {
+		return ResponseEntity.ok(
+			partnerGymService.getPartnerGymDetail(customOAuth2User.getUserId()));
+	}
+
+	// 제휴 헬스장 머신 리스트 조회
+	@PreAuthorize("hasRole('ROLE_TRAINER')")
+	@GetMapping("/machine")
+	public ResponseEntity<List<MachineResponse>> getMachines(
+		@AuthenticationPrincipal CustomOAuth2User customOAuth2User) {
+
+		return ResponseEntity.ok(machineService.getOwnMachines(customOAuth2User.getUserId()));
+	}
+}

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/entity/PartnerGym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/entity/PartnerGym.java
@@ -1,8 +1,9 @@
-package org.helloworld.gymmate.domain.gym.gymInfo.entity;
+package org.helloworld.gymmate.domain.gym.partnerGym.entity;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
 import org.hibernate.annotations.BatchSize;
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/mapper/PartnerGymMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/mapper/PartnerGymMapper.java
@@ -1,4 +1,4 @@
-package org.helloworld.gymmate.domain.gym.gymInfo.mapper;
+package org.helloworld.gymmate.domain.gym.partnerGym.mapper;
 
 import java.util.List;
 
@@ -9,8 +9,8 @@ import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.GymProductResponse
 import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
 import org.helloworld.gymmate.domain.gym.gymInfo.entity.GymImage;
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
 import org.helloworld.gymmate.domain.gym.gymProduct.entity.GymProduct;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
 
 public class PartnerGymMapper {
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/repository/PartnerGymRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/repository/PartnerGymRepository.java
@@ -1,8 +1,8 @@
-package org.helloworld.gymmate.domain.gym.gymInfo.repository;
+package org.helloworld.gymmate.domain.gym.partnerGym.repository;
 
 import java.util.Optional;
 
-import org.helloworld.gymmate.domain.gym.gymInfo.entity.PartnerGym;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -18,4 +18,6 @@ public interface PartnerGymRepository extends JpaRepository<PartnerGym, Long> {
 			WHERE pg.partnerGymId = :partnerGymId
 		""")
 	Optional<PartnerGym> findByIdWithGymAndProducts(@Param("partnerGymId") Long partnerGymId);
+
+	Optional<PartnerGym> findByOwnerId(Long ownerId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/service/PartnerGymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnerGym/service/PartnerGymService.java
@@ -1,0 +1,197 @@
+package org.helloworld.gymmate.domain.gym.partnerGym.service;
+
+import java.util.List;
+
+import org.helloworld.gymmate.common.exception.BusinessException;
+import org.helloworld.gymmate.common.exception.ErrorCode;
+import org.helloworld.gymmate.common.s3.FileManager;
+import org.helloworld.gymmate.common.util.StringUtil;
+import org.helloworld.gymmate.domain.gym.facility.entity.Facility;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.GymInfoRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.RegisterGymRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.request.UpdateGymRequest;
+import org.helloworld.gymmate.domain.gym.gymInfo.dto.response.PartnerGymDetailResponse;
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.Gym;
+import org.helloworld.gymmate.domain.gym.gymInfo.entity.GymImage;
+import org.helloworld.gymmate.domain.gym.gymInfo.mapper.GymMapper;
+import org.helloworld.gymmate.domain.gym.gymInfo.repository.GymRepository;
+import org.helloworld.gymmate.domain.gym.gymInfo.service.GymService;
+import org.helloworld.gymmate.domain.gym.gymProduct.service.GymProductService;
+import org.helloworld.gymmate.domain.gym.partnerGym.entity.PartnerGym;
+import org.helloworld.gymmate.domain.gym.partnerGym.mapper.PartnerGymMapper;
+import org.helloworld.gymmate.domain.gym.partnerGym.repository.PartnerGymRepository;
+import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
+import org.helloworld.gymmate.domain.user.trainer.service.TrainerService;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
+
+import lombok.RequiredArgsConstructor;
+
+@Service
+@RequiredArgsConstructor
+public class PartnerGymService {
+
+	private final PartnerGymRepository partnerGymRepository;
+	private final GymRepository gymRepository;
+	private final FileManager fileManager;
+	private final GymService gymService;
+	private final GymProductService gymProductService;
+	private final TrainerService trainerService;
+
+	//파트너헬스장 조회
+	public Gym getGymByPartnerGymId(Long partnerGymId) {
+		PartnerGym partnerGym = partnerGymRepository.findById(partnerGymId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_GYM_NOT_FOUND));
+
+		return partnerGym.getGym();
+	}
+
+	@Transactional
+	public Long registerPartnerGym(RegisterGymRequest request, List<MultipartFile> images, Long ownerId) {
+		// 운영자 맞는지 확인
+		validatePartnerGymOwner(ownerId);
+
+		// 중복 등록 방지
+		if (partnerGymRepository.existsByOwnerIdAndGym_GymId(ownerId, request.gymId())) {
+			throw new BusinessException(ErrorCode.GYM_ALREADY_EXISTS);
+		}
+
+		// gym 있는지 확인
+		Gym existingGym = gymService.getExistingGym(request.gymId());
+
+		// partnerGym 저장
+		PartnerGym partnerGym = createPartnerGym(ownerId, existingGym);
+
+		// gym 업데이트
+		GymMapper.updateEntity(existingGym, request.gymInfoRequest().gymRequest());
+
+		// facility 업데이트
+		updateFacility(existingGym, request.gymInfoRequest());
+
+		// gymImage 업데이트
+		saveImages(images, existingGym);
+
+		//gymProduct 업데이트
+		gymProductService.updateGymProducts(request.gymProductRequest(), partnerGym);
+
+		return partnerGym.getPartnerGymId();
+	}
+
+	@Transactional
+	public Long updatePartnerGym(UpdateGymRequest request, List<MultipartFile> images,
+		Long ownerId) {
+		// 본인이 운영하는 제휴 헬스장 가져오기
+		PartnerGym partnerGym = getPartnerGymByOwnerId(ownerId);
+
+		// partnerGym 로 Gym 가져오기
+		Gym existingGym = getGymByPartnerGymId(partnerGym.getPartnerGymId());
+
+		// gym 업데이트
+		GymMapper.updateEntity(existingGym, request.gymInfoRequest().gymRequest());
+
+		// facility 업데이트
+		updateFacility(existingGym, request.gymInfoRequest());
+
+		// gymImage 업데이트
+		updateImages(request, images, existingGym);
+
+		// gymProduct 업데이트
+		gymProductService.updateGymProducts(request.gymProductRequest(), partnerGym);
+
+		return existingGym.getGymId();
+	}
+
+	// 제휴 헬스장 조회
+	@Transactional(readOnly = true)
+	public PartnerGymDetailResponse getPartnerGymDetail(Long ownerId) {
+		PartnerGym partnerGym = getPartnerGymByOwnerId(ownerId);
+
+		// Lazy 로딩 유도 (실제 접근 시 쿼리 발생)
+		partnerGym.getGym().getImages().size();
+		partnerGym.getGymProducts().size();
+
+		return PartnerGymMapper.toDto(partnerGym);
+
+	}
+
+	// 가까운 헬스장 조회
+	@Transactional(readOnly = true)
+	public List<Gym> findNearbyGyms(double longitude, double latitude, double radiusInMeters, int limit) {
+		String point = StringUtil.format("POINT({} {})", latitude, longitude);
+		return gymRepository.findNearbyGyms(point, radiusInMeters, limit);
+	}
+
+	private PartnerGym getPartnerGymByOwnerId(Long ownerId) {
+		// 본인이 운영하는 제휴 헬스장 가져오기
+		return partnerGymRepository.findByOwnerId(ownerId)
+			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_AUTHORIZED));
+	}
+
+	private void validatePartnerGymOwner(Long ownerId) {
+		Trainer owner = trainerService.findByUserId(ownerId);
+		if (!owner.getIsOwner()) {
+			throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
+		}
+	}
+
+	private PartnerGym createPartnerGym(Long ownerId, Gym gym) {
+		PartnerGym partnerGym = PartnerGym.builder()
+			.ownerId(ownerId)
+			.gym(gym)
+			.build();
+
+		return partnerGymRepository.save(partnerGym);
+	}
+
+	private List<GymImage> uploadAndMapImages(List<MultipartFile> images, String tableName) {
+		if (images == null || images.isEmpty())
+			return List.of();
+
+		List<String> imageUrls;
+		try {
+			imageUrls = fileManager.uploadFiles(images, tableName);
+		} catch (Exception e) {
+			throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
+		}
+
+		return imageUrls.stream()
+			.map(url -> GymImage.builder().url(url).build())
+			.toList();
+	}
+
+	// 신규 이미지 저장
+	private void saveImages(List<MultipartFile> images, Gym gym) {
+		List<GymImage> gymImages = uploadAndMapImages(images, "gym");
+		gym.addImages(gymImages);
+	}
+
+	// 이미지 삭제 + 새 이미지 등록
+	private void updateImages(UpdateGymRequest request, List<MultipartFile> images, Gym gym) {
+		// 삭제할 이미지 ID 목록
+		List<Long> deleteImageIds = request.deleteImageIds() != null ? request.deleteImageIds() : List.of();
+
+		// 삭제할 이미지 필터링
+		List<GymImage> imagesToDelete = gym.getImages().stream()
+			.filter(img -> deleteImageIds.contains(img.getId()))
+			.toList();
+
+		// S3 + 연관관계 제거
+		for (GymImage image : imagesToDelete) {
+			fileManager.deleteFile(image.getUrl());
+			gym.removeImage(image);
+		}
+
+		// 새 이미지 업로드 및 등록
+		List<GymImage> newImages = uploadAndMapImages(images, "gym");
+		gym.addImages(newImages);
+	}
+
+	private void updateFacility(Gym existingGym, GymInfoRequest request) {
+		Facility facility = existingGym.getFacility();
+		facility.update(request.facilityRequest());
+	}
+}
+
+
+


### PR DESCRIPTION
# 📝 파트너 헬스장 분리

---

## 🔘 Part
- gym

---

## 🔎 작업 내용
- 같이 병합됨:
  #94 
  #95 
- gym 도메인 리팩토링 (기본 헬스장과 파트너 헬스장 분리)
- PartnerGymController: 
  더이상 파라미터로 `partnerId`를 받지 않습니다
  사유: 보안성 개선 (자신의 id 기반으로 조회하도록 해서 자신이 운영하는 헬스장만 접근 가능)
- PartnerGymService: 
  `validatePartnerGymOwner`: 기존에 있던 코드를 메소드로 분리함
  `getPartnerGymByOwnerId`: 자신의 id를 이용해 운영중인 파트너짐을 가져옵니다

---

## 🖼️ 이미지 첨부

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 많이 바뀌었습니다!!

---

## 🔧 앞으로의 과제
- 후순위: (PartnerGymService) `registerPartnerGym`, `updatePartnerGym` 메소드 중복 로직 리팩토링
- GymProductService 구현

---

## ➕ 이슈 링크
- .

---
