### PR TITLE
feat(gym): 헬스장 소속 트레이너 목록 조회

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/controller/GymController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/controller/GymController.java
@@ -1,9 +1,12 @@
 package org.helloworld.gymmate.domain.gym.gyminfo.controller;
 
+import java.util.List;
+
 import org.helloworld.gymmate.common.dto.PageDto;
 import org.helloworld.gymmate.common.mapper.PageMapper;
 import org.helloworld.gymmate.domain.gym.gyminfo.dto.response.GymDetailResponse;
 import org.helloworld.gymmate.domain.gym.gyminfo.dto.response.GymListResponse;
+import org.helloworld.gymmate.domain.gym.gyminfo.dto.response.TrainerDetailResponse;
 import org.helloworld.gymmate.domain.gym.gyminfo.service.GymService;
 import org.helloworld.gymmate.domain.gym.machine.dto.FacilityAndMachineResponse;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
@@ -70,6 +73,14 @@ public class GymController {
 		@PathVariable Long gymId
 	) {
 		return ResponseEntity.ok(gymService.getOwnFacilitiesAndMachines(gymId));
+	}
+
+	//헬스장 소속 트레이너 정보 전체 조회
+	@GetMapping("/{gymId}/trainer")
+	public ResponseEntity<List<TrainerDetailResponse>> getTrainerDetail(
+		@PathVariable Long gymId
+	) {
+		return ResponseEntity.ok(gymService.getTrainerDetail(gymId));
 	}
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/dto/response/TrainerDetailResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/dto/response/TrainerDetailResponse.java
@@ -1,0 +1,28 @@
+package org.helloworld.gymmate.domain.gym.gyminfo.dto.response;
+
+import java.util.List;
+
+public record TrainerDetailResponse(
+	String trainerName,
+	String intro,
+	String field,
+	String career,
+	String profileUrl,
+	List<AwardResponse> awards,
+	List<PtProductResponse> ptProducts
+) {
+
+	public record AwardResponse(
+		String awardYear,
+		String awardName,
+		String awardInfo
+	) {
+	}
+
+	public record PtProductResponse(
+		String ptProductName,
+		int ptProductFee
+	) {
+	}
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/pt/ptproduct/repository/PtProductRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/ptproduct/repository/PtProductRepository.java
@@ -1,5 +1,7 @@
 package org.helloworld.gymmate.domain.pt.ptproduct.repository;
 
+import java.util.List;
+
 import org.helloworld.gymmate.domain.pt.ptproduct.entity.PtProduct;
 import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
@@ -108,4 +110,7 @@ public interface PtProductRepository extends JpaRepository<PtProduct, Long> {
 		@Param("x") Double x, @Param("y") Double y,
 		@Param("ptProductSearchOption") String ptProductSearchOption, @Param("searchTerm") String searchTerm,
 		Pageable pageable);
+
+	List<PtProduct> findByTrainerIdIn(List<Long> trainerIds);
+
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/mapper/TrainerMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/mapper/TrainerMapper.java
@@ -4,13 +4,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 
+import org.helloworld.gymmate.domain.gym.gyminfo.dto.response.TrainerDetailResponse;
+import org.helloworld.gymmate.domain.pt.ptproduct.entity.PtProduct;
 import org.helloworld.gymmate.domain.user.enums.UserType;
+import org.helloworld.gymmate.domain.user.trainer.award.entity.Award;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerCheckResponse;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerListResponse;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerResponse;
 import org.helloworld.gymmate.domain.user.trainer.model.Trainer;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
+import org.springframework.stereotype.Component;
 
+@Component
 public class TrainerMapper {
 
 	public static Trainer toTrainer(Oauth oauth) {
@@ -58,4 +63,32 @@ public class TrainerMapper {
 		);
 	}
 
+	public TrainerDetailResponse toTrainerDetailResponse(
+		Trainer trainer,
+		List<Award> awards,
+		List<PtProduct> ptProducts
+	) {
+		List<TrainerDetailResponse.AwardResponse> awardDtos = awards.stream()
+			.map(award -> new TrainerDetailResponse.AwardResponse(
+				award.getAwardYear(),
+				award.getAwardName(),
+				award.getAwardInfo()
+			)).toList();
+
+		List<TrainerDetailResponse.PtProductResponse> productDtos = ptProducts.stream()
+			.map(p -> new TrainerDetailResponse.PtProductResponse(
+				p.getPtProductName(),
+				p.getPtProductFee().intValue()
+			)).toList();
+
+		return new TrainerDetailResponse(
+			trainer.getTrainerName(),
+			trainer.getIntro(),
+			trainer.getField(),
+			trainer.getCareer(),
+			trainer.getProfile(),
+			awardDtos,
+			productDtos
+		);
+	}
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/repository/TrainerRepository.java
@@ -59,4 +59,7 @@ public interface TrainerRepository extends JpaRepository<Trainer, Long> {
 		@Param("x") Double x, @Param("y") Double y,
 		@Param("searchOption") String searchOption, @Param("searchTerm") String searchTerm,
 		Pageable pageable);
+
+	List<Trainer> findByGym_GymId(Long gymId);
+
 }


### PR DESCRIPTION
## 🔘 Part
- gym

---

## 🔎 작업 내용
- gymId로 소속 트레이너 전체 조회 API 
- 트레이너 정보 + 수상 이력 + PT 상품 포함
- 연관관계 없이 각각 조회 후 Java에서 그룹핑 처리
- TrainerMapper 분리 및 응답 DTO 매핑

---

## 🖼️ 이미지 첨부
<img src="https://i.postimg.cc/SN2TS0kz/image.png" width="50%" />

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- GYMMATE-233

---
