### PR TITLE
refactor(gym) : 헬스장 단일 정보 조회시 이용권 정보 추가 

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/dto/response/GymDetailResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/dto/response/GymDetailResponse.java
@@ -2,18 +2,21 @@ package org.helloworld.gymmate.domain.gym.gyminfo.dto.response;
 
 import java.util.List;
 
+import org.helloworld.gymmate.domain.gym.partnergym.dto.response.GymProductResponse;
+
 public record GymDetailResponse(
-	Long gymId,
-	String gymName,
-	String startTime,
-	String endTime,
-	String phoneNumber,
-	String address,
-	String xField,
-	String yField,
-	Double avgScore,
-	String intro,
-	Boolean isPartner,
-	List<String> gymImages
+    Long gymId,
+    String gymName,
+    String startTime,
+    String endTime,
+    String phoneNumber,
+    String address,
+    String xField,
+    String yField,
+    Double avgScore,
+    String intro,
+    Boolean isPartner,
+    List<String> gymImages,
+    List<GymProductResponse> gymProductResponses
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/entity/Gym.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/entity/Gym.java
@@ -35,78 +35,82 @@ import lombok.With;
 @Table(name = "gym")
 public class Gym {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "gym_id", nullable = false)
-	private Long gymId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "gym_id", nullable = false)
+    private Long gymId;
 
-	@Column(name = "gym_name", nullable = false)
-	private String gymName;
+    @Column(name = "gym_name", nullable = false)
+    private String gymName;
 
-	@Column(name = "start_time", nullable = false)  //크롤링 해서 없는 경우 "운영시간이 없습니다" 표시
-	private String startTime;
+    @Column(name = "start_time", nullable = false)  //크롤링 해서 없는 경우 "운영시간이 없습니다" 표시
+    private String startTime;
 
-	@Column(name = "end_time", nullable = false) //크롤링 해서 없는 경우 "운영시간이 없습니다" 표시
-	private String endTime;
+    @Column(name = "end_time", nullable = false) //크롤링 해서 없는 경우 "운영시간이 없습니다" 표시
+    private String endTime;
 
-	@Column(name = "phone_number", nullable = true) //헬스장 번호가 없는 경우 존재함
-	private String phoneNumber;
+    @Column(name = "phone_number", nullable = true) //헬스장 번호가 없는 경우 존재함
+    private String phoneNumber;
 
-	@Column(name = "is_partner", nullable = false)
-	private Boolean isPartner;
+    @Column(name = "is_partner", nullable = false)
+    private Boolean isPartner;
 
-	@Column(name = "address", nullable = false)
-	private String address;
+    @Column(name = "address", nullable = false)
+    private String address;
 
-	@Column(name = "location", columnDefinition = "POINT SRID 4326", nullable = false)
-	private Point location;
+    @Column(name = "location", columnDefinition = "POINT SRID 4326", nullable = false)
+    private Point location;
 
-	@Column(name = "avg_score", nullable = false)
-	private Double avgScore;
+    @Column(name = "avg_score", nullable = false)
+    private Double avgScore;
 
-	@Column(name = "intro", nullable = false)
-	private String intro;
+    @Column(name = "intro", nullable = false)
+    private String intro;
 
-	@Column(name = "place_url") //헬스장 상세 정보URL
-	private String placeUrl;
+    @Column(name = "place_url") //헬스장 상세 정보URL
+    private String placeUrl;
 
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-	@JoinColumn(name = "facility_id")
-	private Facility facility;
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "facility_id")
+    private Facility facility;
 
-	@OneToMany(mappedBy = "gym", cascade = CascadeType.ALL, orphanRemoval = true)
-	@BatchSize(size = 20)
-	@Builder.Default
-	private List<GymImage> images = new ArrayList<>();  //이미지의 경우 default이미지 표시
+    @OneToMany(mappedBy = "gym", cascade = CascadeType.ALL, orphanRemoval = true)
+    @BatchSize(size = 20)
+    @Builder.Default
+    private List<GymImage> images = new ArrayList<>();  //이미지의 경우 default이미지 표시
 
-	@OneToMany(mappedBy = "gym", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<Machine> machines = new ArrayList<>();
+    @OneToMany(mappedBy = "gym", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<Machine> machines = new ArrayList<>();
 
-	// ====== Business Logic ======
+    // ====== Business Logic ======
 
-	public void addImages(List<GymImage> images) {
-		this.images.addAll(images);
-		images.forEach(img -> img.setGym(this));
-	}
+    public void addImages(List<GymImage> images) {
+        this.images.addAll(images);
+        images.forEach(img -> img.setGym(this));
+    }
 
-	public void removeImage(GymImage image) {
-		images.remove(image);
-		image.setGym(null);
-	}
+    public void removeImage(GymImage image) {
+        images.remove(image);
+        image.setGym(null);
+    }
 
-	public void updateInfo(
-		String startTime,
-		String endTime,
-		String intro
-	) {
-		this.startTime = startTime;
-		this.endTime = endTime;
-		this.intro = intro;
-	}
+    public void updateInfo(
+        String startTime,
+        String endTime,
+        String intro
+    ) {
+        this.startTime = startTime;
+        this.endTime = endTime;
+        this.intro = intro;
+    }
 
-	public void assignFacility(Facility facility) {
-		this.facility = facility;
-	}
+    public void assignFacility(Facility facility) {
+        this.facility = facility;
+    }
+
+    public void updatePartner(Boolean isPartner) {
+        this.isPartner = isPartner;
+    }
 }
 

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/mapper/GymMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/mapper/GymMapper.java
@@ -1,5 +1,6 @@
 package org.helloworld.gymmate.domain.gym.gyminfo.mapper;
 
+import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 
@@ -9,82 +10,84 @@ import org.helloworld.gymmate.domain.gym.gyminfo.dto.response.GymListResponse;
 import org.helloworld.gymmate.domain.gym.gyminfo.entity.Gym;
 import org.helloworld.gymmate.domain.gym.gyminfo.entity.GymImage;
 import org.helloworld.gymmate.domain.gym.partnergym.dto.request.GymRequest;
+import org.helloworld.gymmate.domain.gym.partnergym.dto.response.GymProductResponse;
 
 public class GymMapper {
-	public static void updateEntity(Gym gym, GymRequest request) {
-		gym.updateInfo(
-			request.startTime(),
-			request.endTime(),
-			request.intro()
-		);
-	}
+    public static void updateEntity(Gym gym, GymRequest request) {
+        gym.updateInfo(
+            request.startTime(),
+            request.endTime(),
+            request.intro()
+        );
+    }
 
-	// 크롤링 1단계 (api에서 영업시간, 이미지 빼고 전부 받아옴)
-	// TODO : 디폴트 이미지 랜덤 구현
-	public static Gym toEntity(Map<String, Object> response) {
-		double x = parseToDouble(response.get("x"));
-		double y = parseToDouble(response.get("y"));
-		return Gym.builder()
-			.gymName((String)response.get("place_name"))
-			.startTime(null)
-			.endTime(null)
-			.phoneNumber((String)response.get("phone"))
-			.isPartner(false)
-			.address((String)response.get("road_address_name"))
-			.location(GeometryUtil.createPoint(x, y))
-			.intro(null)
-			.avgScore(0.0)
-			.placeUrl((String)response.get("place_url"))
-			.build();
-	}
+    // 크롤링 1단계 (api에서 영업시간, 이미지 빼고 전부 받아옴)
+    // TODO : 디폴트 이미지 랜덤 구현
+    public static Gym toEntity(Map<String, Object> response) {
+        double x = parseToDouble(response.get("x"));
+        double y = parseToDouble(response.get("y"));
+        return Gym.builder()
+            .gymName((String)response.get("place_name"))
+            .startTime(null)
+            .endTime(null)
+            .phoneNumber((String)response.get("phone"))
+            .isPartner(false)
+            .address((String)response.get("road_address_name"))
+            .location(GeometryUtil.createPoint(x, y))
+            .intro(null)
+            .avgScore(0.0)
+            .placeUrl((String)response.get("place_url"))
+            .build();
+    }
 
-	private static double parseToDouble(Object value) {
-		if (value instanceof Number) {
-			return ((Number)value).doubleValue();
-		} else if (value instanceof String) {
-			try {
-				return Double.parseDouble((String)value);
-			} catch (NumberFormatException e) {
-				throw new IllegalArgumentException("좌표 변환 실패: " + value, e);
-			}
-		} else {
-			throw new IllegalArgumentException("잘못된 좌표 타입: " + value);
-		}
-	}
+    private static double parseToDouble(Object value) {
+        if (value instanceof Number) {
+            return ((Number)value).doubleValue();
+        } else if (value instanceof String) {
+            try {
+                return Double.parseDouble((String)value);
+            } catch (NumberFormatException e) {
+                throw new IllegalArgumentException("좌표 변환 실패: " + value, e);
+            }
+        } else {
+            throw new IllegalArgumentException("잘못된 좌표 타입: " + value);
+        }
+    }
 
-	public static GymListResponse toListResponse(Gym gym) {
-		return new GymListResponse(
-			gym.getGymId(),
-			gym.getGymName(),
-			gym.getStartTime(),
-			gym.getEndTime(),
-			gym.getAddress(),
-			String.valueOf(gym.getLocation().getX()),
-			String.valueOf(gym.getLocation().getY()),
-			gym.getAvgScore(),
-			gym.getIsPartner(),
-			Optional.ofNullable(gym.getImages())
-				.filter(images -> !images.isEmpty())
-				.map(images -> images.getFirst().getUrl())
-				.orElse(null)
-		);
-	}
+    public static GymListResponse toListResponse(Gym gym) {
+        return new GymListResponse(
+            gym.getGymId(),
+            gym.getGymName(),
+            gym.getStartTime(),
+            gym.getEndTime(),
+            gym.getAddress(),
+            String.valueOf(gym.getLocation().getX()),
+            String.valueOf(gym.getLocation().getY()),
+            gym.getAvgScore(),
+            gym.getIsPartner(),
+            Optional.ofNullable(gym.getImages())
+                .filter(images -> !images.isEmpty())
+                .map(images -> images.getFirst().getUrl())
+                .orElse(null)
+        );
+    }
 
-	public static GymDetailResponse toDetailResponse(Gym gym) {
-		return new GymDetailResponse(
-			gym.getGymId(),
-			gym.getGymName(),
-			gym.getStartTime(),
-			gym.getEndTime(),
-			gym.getPhoneNumber(),
-			gym.getAddress(),
-			String.valueOf(gym.getLocation().getX()),
-			String.valueOf(gym.getLocation().getY()),
-			gym.getAvgScore(),
-			gym.getIntro(),
-			gym.getIsPartner(),
-			gym.getImages().stream().map(GymImage::getUrl).toList()
-		);
-	}
+    public static GymDetailResponse toDetailResponse(Gym gym, List<GymProductResponse> gymProductResponseList) {
+        return new GymDetailResponse(
+            gym.getGymId(),
+            gym.getGymName(),
+            gym.getStartTime(),
+            gym.getEndTime(),
+            gym.getPhoneNumber(),
+            gym.getAddress(),
+            String.valueOf(gym.getLocation().getX()),
+            String.valueOf(gym.getLocation().getY()),
+            gym.getAvgScore(),
+            gym.getIntro(),
+            gym.getIsPartner(),
+            gym.getImages().stream().map(GymImage::getUrl).toList(),
+            gymProductResponseList
+        );
+    }
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/service/GymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gyminfo/service/GymService.java
@@ -1,5 +1,6 @@
 package org.helloworld.gymmate.domain.gym.gyminfo.service;
 
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
@@ -16,17 +17,20 @@ import org.helloworld.gymmate.domain.gym.gyminfo.dto.response.TrainerDetailRespo
 import org.helloworld.gymmate.domain.gym.gyminfo.entity.Gym;
 import org.helloworld.gymmate.domain.gym.gyminfo.mapper.GymMapper;
 import org.helloworld.gymmate.domain.gym.gyminfo.repository.GymRepository;
+import org.helloworld.gymmate.domain.gym.gymproduct.mapper.GymProductMapper;
 import org.helloworld.gymmate.domain.gym.machine.dto.FacilityAndMachineResponse;
 import org.helloworld.gymmate.domain.gym.machine.dto.MachineResponse;
 import org.helloworld.gymmate.domain.gym.machine.mapper.MachineMapper;
+import org.helloworld.gymmate.domain.gym.partnergym.dto.response.GymProductResponse;
+import org.helloworld.gymmate.domain.gym.partnergym.repository.PartnerGymRepository;
 import org.helloworld.gymmate.domain.pt.ptproduct.entity.PtProduct;
 import org.helloworld.gymmate.domain.pt.ptproduct.repository.PtProductRepository;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.domain.user.member.service.MemberService;
 import org.helloworld.gymmate.domain.user.trainer.award.entity.Award;
 import org.helloworld.gymmate.domain.user.trainer.award.repository.AwardRepository;
-import org.helloworld.gymmate.domain.user.trainer.mapper.TrainerMapper;
 import org.helloworld.gymmate.domain.user.trainer.entity.Trainer;
+import org.helloworld.gymmate.domain.user.trainer.mapper.TrainerMapper;
 import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.data.domain.Page;
@@ -41,117 +45,126 @@ import lombok.RequiredArgsConstructor;
 @Service
 @RequiredArgsConstructor
 public class GymService {
-	private final GymRepository gymRepository;
-	private final MemberService memberService;
-	private final TrainerRepository trainerRepository;
-	private final TrainerMapper trainerMapper;
-	private final AwardRepository awardRepository;
-	private final PtProductRepository ptProductRepository;
+    private final GymRepository gymRepository;
+    private final MemberService memberService;
+    private final TrainerRepository trainerRepository;
+    private final TrainerMapper trainerMapper;
+    private final AwardRepository awardRepository;
+    private final PtProductRepository ptProductRepository;
+    private final PartnerGymRepository partnerGymRepository;
 
-	@Transactional(readOnly = true)
-	public FacilityAndMachineResponse getOwnFacilitiesAndMachines(Long gymId) {
-		Gym gym = getExistingGym(gymId);
-		FacilityResponse facilityResponse = getFacility(gym);
-		List<MachineResponse> machineResponses = MachineMapper.toDtoList(gym.getMachines());
-		return new FacilityAndMachineResponse(facilityResponse, machineResponses);
-	}
+    @Transactional(readOnly = true)
+    public FacilityAndMachineResponse getOwnFacilitiesAndMachines(Long gymId) {
+        Gym gym = getExistingGym(gymId);
+        FacilityResponse facilityResponse = getFacility(gym);
+        List<MachineResponse> machineResponses = MachineMapper.toDtoList(gym.getMachines());
+        return new FacilityAndMachineResponse(facilityResponse, machineResponses);
+    }
 
-	// 헬스장 조회 (외부에서 호출하는 부분이 있어서 Transactional 추가)
-	@Transactional(readOnly = true)
-	public Gym getExistingGym(Long gymId) {
-		return gymRepository.findById(gymId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.GYM_NOT_FOUND));
-	}
+    // 헬스장 조회 (외부에서 호출하는 부분이 있어서 Transactional 추가)
+    @Transactional(readOnly = true)
+    public Gym getExistingGym(Long gymId) {
+        return gymRepository.findById(gymId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.GYM_NOT_FOUND));
+    }
 
-	// 편의시설 조회
-	private FacilityResponse getFacility(Gym gym) {
-		return FacilityMapper.toDto(gym.getFacility());
-	}
+    // 편의시설 조회
+    private FacilityResponse getFacility(Gym gym) {
+        return FacilityMapper.toDto(gym.getFacility());
+    }
 
-	@Transactional(readOnly = true)
-	public Page<GymListResponse> getGyms(String sortOption, String searchOption, String searchTerm,
-		int page, int pageSize, Double x, Double y, Boolean isPartner) {
-		GymSortOption sort = GymSortOption.from(sortOption);
-		GymSearchOption search = GymSearchOption.from(searchOption);
-		Pageable pageable = PageRequest.of(page, pageSize);
+    @Transactional(readOnly = true)
+    public Page<GymListResponse> getGyms(String sortOption, String searchOption, String searchTerm,
+        int page, int pageSize, Double x, Double y, Boolean isPartner) {
+        GymSortOption sort = GymSortOption.from(sortOption);
+        GymSearchOption search = GymSearchOption.from(searchOption);
+        Pageable pageable = PageRequest.of(page, pageSize);
 
-		return switch (sort) {
-			case SCORE -> fetchScoreSortedGyms(search, searchTerm, pageable, isPartner);
-			case NEARBY -> fetchNearbyGymsUsingXY(search, searchTerm, pageable, x, y, isPartner);
-		};
-	}
+        return switch (sort) {
+            case SCORE -> fetchScoreSortedGyms(search, searchTerm, pageable, isPartner);
+            case NEARBY -> fetchNearbyGymsUsingXY(search, searchTerm, pageable, x, y, isPartner);
+        };
+    }
 
-	@Transactional(readOnly = true)
-	public Page<GymListResponse> fetchScoreSortedGyms(GymSearchOption search, String searchTerm,
-		Pageable pageable, Boolean isPartner) {
-		Page<Gym> gyms = switch (search) {
-			case NONE -> gymRepository.findAll(isPartner, pageable);
-			case GYM -> gymRepository.searchGymByGymName(searchTerm, isPartner,
-				pageable);
-			case DISTRICT -> gymRepository.searchGymByAddress(searchTerm, isPartner, pageable);
-		};
-		return fetchAndMapGyms(gyms, pageable);
-	}
+    @Transactional(readOnly = true)
+    public Page<GymListResponse> fetchScoreSortedGyms(GymSearchOption search, String searchTerm,
+        Pageable pageable, Boolean isPartner) {
+        Page<Gym> gyms = switch (search) {
+            case NONE -> gymRepository.findAll(isPartner, pageable);
+            case GYM -> gymRepository.searchGymByGymName(searchTerm, isPartner,
+                pageable);
+            case DISTRICT -> gymRepository.searchGymByAddress(searchTerm, isPartner, pageable);
+        };
+        return fetchAndMapGyms(gyms, pageable);
+    }
 
-	@Transactional(readOnly = true)
-	public Page<GymListResponse> getNearbyGyms(String searchOption, String searchTerm, int page,
-		int pageSize, Boolean isPartner, CustomOAuth2User customOAuth2User) {
-		GymSearchOption search = GymSearchOption.from(searchOption);
-		Member member = memberService.findByUserId(customOAuth2User.getUserId());
-		Double x = Double.valueOf(member.getXField());
-		Double y = Double.valueOf(member.getYField());
-		Pageable pageable = PageRequest.of(page, pageSize);
-		return fetchNearbyGymsUsingXY(search, searchTerm, pageable, x, y, isPartner);
-	}
+    @Transactional(readOnly = true)
+    public Page<GymListResponse> getNearbyGyms(String searchOption, String searchTerm, int page,
+        int pageSize, Boolean isPartner, CustomOAuth2User customOAuth2User) {
+        GymSearchOption search = GymSearchOption.from(searchOption);
+        Member member = memberService.findByUserId(customOAuth2User.getUserId());
+        Double x = member.getXField();
+        Double y = member.getYField();
+        Pageable pageable = PageRequest.of(page, pageSize);
+        return fetchNearbyGymsUsingXY(search, searchTerm, pageable, x, y, isPartner);
+    }
 
-	@Transactional(readOnly = true)
-	public Page<GymListResponse> fetchNearbyGymsUsingXY(GymSearchOption gymSearchOption,
-		String searchTerm, Pageable pageable, Double x, Double y, Boolean isPartner) {
-		String searchValue = (gymSearchOption == GymSearchOption.NONE) ? "" : searchTerm;
-		Page<Gym> gyms = gymRepository.findNearByGymWithSearchAndIsPartner(x, y,
-			gymSearchOption.name(),
-			searchValue, isPartner, pageable);
+    @Transactional(readOnly = true)
+    public Page<GymListResponse> fetchNearbyGymsUsingXY(GymSearchOption gymSearchOption,
+        String searchTerm, Pageable pageable, Double x, Double y, Boolean isPartner) {
+        String searchValue = (gymSearchOption == GymSearchOption.NONE) ? "" : searchTerm;
+        Page<Gym> gyms = gymRepository.findNearByGymWithSearchAndIsPartner(x, y,
+            gymSearchOption.name(),
+            searchValue, isPartner, pageable);
 
-		return fetchAndMapGyms(gyms, pageable);
-	}
+        return fetchAndMapGyms(gyms, pageable);
+    }
 
-	@Transactional(readOnly = true)
-	public Page<GymListResponse> fetchAndMapGyms(Page<Gym> gyms, Pageable pageable) {
-		List<GymListResponse> responses = gyms.stream()
-			.map(GymMapper::toListResponse)
-			.toList();
+    @Transactional(readOnly = true)
+    public Page<GymListResponse> fetchAndMapGyms(Page<Gym> gyms, Pageable pageable) {
+        List<GymListResponse> responses = gyms.stream()
+            .map(GymMapper::toListResponse)
+            .toList();
 
-		return new PageImpl<>(responses, pageable, gyms.getTotalElements());
-	}
+        return new PageImpl<>(responses, pageable, gyms.getTotalElements());
+    }
 
-	@Transactional(readOnly = true)
-	public GymDetailResponse getDetail(Long gymId) {
-		Gym gym = getExistingGym(gymId);
-		return GymMapper.toDetailResponse(gym);
-	}
+    @Transactional(readOnly = true)
+    public GymDetailResponse getDetail(Long gymId) {
+        Gym gym = getExistingGym(gymId);
+        List<GymProductResponse> gymProducts = new ArrayList<>();
+        if (gym.getIsPartner()) {
+            gymProducts = partnerGymRepository.findByGym_GymId(gymId)
+                .getGymProducts()
+                .stream()
+                .map(GymProductMapper::toResponse)
+                .toList();
+        }
+        return GymMapper.toDetailResponse(gym, gymProducts);
+    }
 
-	public List<TrainerDetailResponse> getTrainerDetail(Long gymId) {
-		List<Trainer> trainers = trainerRepository.findByGym_GymId(gymId);
-		List<Long> trainerIds = trainers.stream()
-			.map(Trainer::getTrainerId)
-			.toList();
+    public List<TrainerDetailResponse> getTrainerDetail(Long gymId) {
+        List<Trainer> trainers = trainerRepository.findByGym_GymId(gymId);
+        List<Long> trainerIds = trainers.stream()
+            .map(Trainer::getTrainerId)
+            .toList();
 
-		List<Award> awards = awardRepository.findByTrainerIdIn(trainerIds);
-		List<PtProduct> ptProducts = ptProductRepository.findByTrainerIdIn(trainerIds);
+        List<Award> awards = awardRepository.findByTrainerIdIn(trainerIds);
+        List<PtProduct> ptProducts = ptProductRepository.findByTrainerIdIn(trainerIds);
 
-		//트레이너별로 묶기
-		Map<Long, List<Award>> awardMap = awards.stream()
-			.collect(Collectors.groupingBy(Award::getTrainerId));
+        //트레이너별로 묶기
+        Map<Long, List<Award>> awardMap = awards.stream()
+            .collect(Collectors.groupingBy(Award::getTrainerId));
 
-		Map<Long, List<PtProduct>> productMap = ptProducts.stream()
-			.collect(Collectors.groupingBy(PtProduct::getTrainerId));
+        Map<Long, List<PtProduct>> productMap = ptProducts.stream()
+            .collect(Collectors.groupingBy(PtProduct::getTrainerId));
 
-		return trainers.stream()
-			.map(trainer -> trainerMapper.toTrainerDetailResponse(
-				trainer,
-				awardMap.getOrDefault(trainer.getTrainerId(), List.of()),
-				productMap.getOrDefault(trainer.getTrainerId(), List.of())
-			))
-			.toList();
-	}
+        return trainers.stream()
+            .map(trainer -> trainerMapper.toTrainerDetailResponse(
+                trainer,
+                awardMap.getOrDefault(trainer.getTrainerId(), List.of()),
+                productMap.getOrDefault(trainer.getTrainerId(), List.of())
+            ))
+            .toList();
+    }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/gymproduct/mapper/GymProductMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/gymproduct/mapper/GymProductMapper.java
@@ -2,18 +2,27 @@ package org.helloworld.gymmate.domain.gym.gymproduct.mapper;
 
 import org.helloworld.gymmate.domain.gym.gymproduct.dto.GymProductRequest;
 import org.helloworld.gymmate.domain.gym.gymproduct.entity.GymProduct;
+import org.helloworld.gymmate.domain.gym.partnergym.dto.response.GymProductResponse;
 import org.helloworld.gymmate.domain.gym.partnergym.entity.PartnerGym;
 
 import jakarta.validation.Valid;
 
 public class GymProductMapper {
-	public static GymProduct toEntity(@Valid GymProductRequest request, PartnerGym partnerGym) {
-		return GymProduct.builder()
-			.gymProductName(request.gymProductName())
-			.gymProductFee(request.gymProductFee())
-			.gymProductMonth(request.gymProductMonth())
-			.onSale(true)
-			.partnerGym(partnerGym)
-			.build();
-	}
+    public static GymProduct toEntity(@Valid GymProductRequest request, PartnerGym partnerGym) {
+        return GymProduct.builder()
+            .gymProductName(request.gymProductName())
+            .gymProductFee(request.gymProductFee())
+            .gymProductMonth(request.gymProductMonth())
+            .onSale(true)
+            .partnerGym(partnerGym)
+            .build();
+    }
+
+    public static GymProductResponse toResponse(GymProduct gymProduct) {
+        return new GymProductResponse(
+            gymProduct.getGymProductId(),
+            gymProduct.getGymProductMonth(),
+            gymProduct.getGymProductFee()
+        );
+    }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnergym/repository/PartnerGymRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnergym/repository/PartnerGymRepository.java
@@ -12,18 +12,20 @@ import org.springframework.data.repository.query.Param;
 
 public interface PartnerGymRepository extends JpaRepository<PartnerGym, Long> {
 
-	boolean existsByOwnerIdAndGym_GymId(Long ownerId, Long gymId);
+    boolean existsByOwnerIdAndGym_GymId(Long ownerId, Long gymId);
 
-	@Query("""
-			SELECT DISTINCT pg FROM PartnerGym pg
-			JOIN FETCH pg.gym g
-			LEFT JOIN FETCH g.facility
-			WHERE pg.partnerGymId = :partnerGymId
-		""")
-	Optional<PartnerGym> findByIdWithGymAndProducts(@Param("partnerGymId") Long partnerGymId);
+    @Query("""
+        	SELECT DISTINCT pg FROM PartnerGym pg
+        	JOIN FETCH pg.gym g
+        	LEFT JOIN FETCH g.facility
+        	WHERE pg.partnerGymId = :partnerGymId
+        """)
+    Optional<PartnerGym> findByIdWithGymAndProducts(@Param("partnerGymId") Long partnerGymId);
 
-	Optional<PartnerGym> findByOwnerId(Long ownerId);
+    Optional<PartnerGym> findByOwnerId(Long ownerId);
 
-	@Query("SELECT pg.partnerGymId AS partnerGymId, pg.gym.gymName AS gymName FROM PartnerGym pg WHERE pg.partnerGymId IN :ids")
-	List<PartnerGymNameProjection> findGymNamesByPartnerGymIds(@Param("ids") Collection<Long> ids);
+    @Query("SELECT pg.partnerGymId AS partnerGymId, pg.gym.gymName AS gymName FROM PartnerGym pg WHERE pg.partnerGymId IN :ids")
+    List<PartnerGymNameProjection> findGymNamesByPartnerGymIds(@Param("ids") Collection<Long> ids);
+
+    PartnerGym findByGym_GymId(Long gymId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/gym/partnergym/service/PartnerGymService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/gym/partnergym/service/PartnerGymService.java
@@ -34,172 +34,174 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public class PartnerGymService {
 
-	private final PartnerGymRepository partnerGymRepository;
-	private final GymRepository gymRepository;
-	private final FileManager fileManager;
-	private final GymService gymService;
-	private final GymProductService gymProductService;
-	private final TrainerService trainerService;
+    private final PartnerGymRepository partnerGymRepository;
+    private final GymRepository gymRepository;
+    private final FileManager fileManager;
+    private final GymService gymService;
+    private final GymProductService gymProductService;
+    private final TrainerService trainerService;
 
-	//파트너헬스장 조회
-	public Gym getGymByPartnerGymId(Long partnerGymId) {
-		PartnerGym partnerGym = partnerGymRepository.findById(partnerGymId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_GYM_NOT_FOUND));
+    //파트너헬스장 조회
+    public Gym getGymByPartnerGymId(Long partnerGymId) {
+        PartnerGym partnerGym = partnerGymRepository.findById(partnerGymId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.PARTNER_GYM_NOT_FOUND));
 
-		return partnerGym.getGym();
-	}
+        return partnerGym.getGym();
+    }
 
-	@Transactional
-	public Long registerPartnerGym(GymRegisterRequest request, List<MultipartFile> images, Long ownerId) {
-		// 운영자 맞는지 확인
-		validatePartnerGymOwner(ownerId);
+    @Transactional
+    public Long registerPartnerGym(GymRegisterRequest request, List<MultipartFile> images, Long ownerId) {
+        // 운영자 맞는지 확인
+        validatePartnerGymOwner(ownerId);
 
-		// 중복 등록 방지
-		if (partnerGymRepository.existsByOwnerIdAndGym_GymId(ownerId, request.gymId())) {
-			throw new BusinessException(ErrorCode.GYM_ALREADY_EXISTS);
-		}
+        // 중복 등록 방지
+        if (partnerGymRepository.existsByOwnerIdAndGym_GymId(ownerId, request.gymId())) {
+            throw new BusinessException(ErrorCode.GYM_ALREADY_EXISTS);
+        }
 
-		// gym 있는지 확인
-		Gym existingGym = gymService.getExistingGym(request.gymId());
+        // gym 있는지 확인
+        Gym existingGym = gymService.getExistingGym(request.gymId());
 
-		// partnerGym 저장
-		PartnerGym partnerGym = createPartnerGym(ownerId, existingGym);
+        // partnerGym 저장
+        PartnerGym partnerGym = createPartnerGym(ownerId, existingGym);
 
-		// 전체 정보 업데이트
-		updatePartnerGymInfos(request.gymInfoRequest(), null, images, existingGym, partnerGym);
+        // 전체 정보 업데이트
+        updatePartnerGymInfos(request.gymInfoRequest(), null, images, existingGym, partnerGym);
 
-		return partnerGym.getPartnerGymId();
-	}
+        return partnerGym.getPartnerGymId();
+    }
 
-	@Transactional
-	public Long updatePartnerGym(GymUpdateRequest request, List<MultipartFile> images,
-		Long ownerId) {
-		// 본인이 운영하는 제휴 헬스장 가져오기
-		PartnerGym partnerGym = getPartnerGymByOwnerId(ownerId);
+    @Transactional
+    public Long updatePartnerGym(GymUpdateRequest request, List<MultipartFile> images,
+        Long ownerId) {
+        // 본인이 운영하는 제휴 헬스장 가져오기
+        PartnerGym partnerGym = getPartnerGymByOwnerId(ownerId);
 
-		// partnerGym 로 Gym 가져오기
-		Gym existingGym = getGymByPartnerGymId(partnerGym.getPartnerGymId());
+        // partnerGym 로 Gym 가져오기
+        Gym existingGym = getGymByPartnerGymId(partnerGym.getPartnerGymId());
 
-		// 전체 정보 업데이트
-		updatePartnerGymInfos(request.gymInfoRequest(), request.deleteImageIds(), images, existingGym, partnerGym);
+        // 전체 정보 업데이트
+        updatePartnerGymInfos(request.gymInfoRequest(), request.deleteImageIds(), images, existingGym, partnerGym);
 
-		return partnerGym.getPartnerGymId();
-	}
+        return partnerGym.getPartnerGymId();
+    }
 
-	private void updatePartnerGymInfos(GymInfoRequest gymInfoRequest, List<Long> deleteImageIds,
-		List<MultipartFile> images,
-		Gym existingGym,
-		PartnerGym partnerGym) {
-		// gym 업데이트
-		GymMapper.updateEntity(existingGym, gymInfoRequest.gymRequest());
+    private void updatePartnerGymInfos(GymInfoRequest gymInfoRequest, List<Long> deleteImageIds,
+        List<MultipartFile> images,
+        Gym existingGym,
+        PartnerGym partnerGym) {
+        // gym 업데이트
+        GymMapper.updateEntity(existingGym, gymInfoRequest.gymRequest());
 
-		// facility 업데이트
-		updateFacility(existingGym, gymInfoRequest);
+        // facility 업데이트
+        updateFacility(existingGym, gymInfoRequest);
 
-		// gymImage 업데이트
-		updateImages(deleteImageIds, images, existingGym);
+        // gymImage 업데이트
+        updateImages(deleteImageIds, images, existingGym);
 
-		// gymProduct 업데이트
-		gymProductService.updateGymProducts(gymInfoRequest, partnerGym);
-	}
+        // gymProduct 업데이트
+        gymProductService.updateGymProducts(gymInfoRequest, partnerGym);
+    }
 
-	// 제휴 헬스장 조회
-	@Transactional(readOnly = true)
-	public PartnerGymDetailResponse getPartnerGymDetail(Long ownerId) {
-		PartnerGym partnerGym = getPartnerGymByOwnerId(ownerId);
+    // 제휴 헬스장 조회
+    @Transactional(readOnly = true)
+    public PartnerGymDetailResponse getPartnerGymDetail(Long ownerId) {
+        PartnerGym partnerGym = getPartnerGymByOwnerId(ownerId);
 
-		// Lazy 로딩 유도 (실제 접근 시 쿼리 발생)
-		partnerGym.getGym().getImages().size();
-		partnerGym.getGymProducts().size();
+        // Lazy 로딩 유도 (실제 접근 시 쿼리 발생)
+        partnerGym.getGym().getImages().size();
+        partnerGym.getGymProducts().size();
 
-		return PartnerGymMapper.toDto(partnerGym);
+        return PartnerGymMapper.toDto(partnerGym);
 
-	}
+    }
 
-	// 가까운 헬스장 조회
-	@Transactional(readOnly = true)
-	public List<Gym> findNearbyGyms(double longitude, double latitude, double radiusInMeters, int limit) {
-		String point = StringUtil.format("POINT({} {})", latitude, longitude);
-		return gymRepository.findNearbyGyms(point, radiusInMeters, limit);
-	}
+    // 가까운 헬스장 조회
+    @Transactional(readOnly = true)
+    public List<Gym> findNearbyGyms(double longitude, double latitude, double radiusInMeters, int limit) {
+        String point = StringUtil.format("POINT({} {})", latitude, longitude);
+        return gymRepository.findNearbyGyms(point, radiusInMeters, limit);
+    }
 
-	public PartnerGym getPartnerGymByOwnerId(Long ownerId) {
-		// 본인이 운영하는 제휴 헬스장 가져오기
-		return partnerGymRepository.findByOwnerId(ownerId)
-			.orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_AUTHORIZED));
-	}
+    public PartnerGym getPartnerGymByOwnerId(Long ownerId) {
+        // 본인이 운영하는 제휴 헬스장 가져오기
+        return partnerGymRepository.findByOwnerId(ownerId)
+            .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_AUTHORIZED));
+    }
 
-	private void validatePartnerGymOwner(Long ownerId) {
-		Trainer owner = trainerService.findByUserId(ownerId);
-		if (!owner.getIsOwner()) {
-			throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
-		}
-	}
+    private void validatePartnerGymOwner(Long ownerId) {
+        Trainer owner = trainerService.findByUserId(ownerId);
+        if (!owner.getIsOwner()) {
+            throw new BusinessException(ErrorCode.GYM_REGISTRATION_FORBIDDEN);
+        }
+    }
 
-	private PartnerGym createPartnerGym(Long ownerId, Gym gym) {
-		PartnerGym partnerGym = PartnerGym.builder()
-			.ownerId(ownerId)
-			.gym(gym)
-			.build();
+    private PartnerGym createPartnerGym(Long ownerId, Gym gym) {
+        PartnerGym partnerGym = PartnerGym.builder()
+            .ownerId(ownerId)
+            .gym(gym)
+            .build();
+		
+        gym.updatePartner(true);
 
-		return partnerGymRepository.save(partnerGym);
-	}
+        return partnerGymRepository.save(partnerGym);
+    }
 
-	private List<GymImage> uploadAndMapImages(List<MultipartFile> images) {
-		if (images == null || images.isEmpty())
-			return List.of();
+    private List<GymImage> uploadAndMapImages(List<MultipartFile> images) {
+        if (images == null || images.isEmpty())
+            return List.of();
 
-		List<String> imageUrls;
-		try {
-			imageUrls = fileManager.uploadFiles(images, "gym");
-		} catch (Exception e) {
-			throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
-		}
+        List<String> imageUrls;
+        try {
+            imageUrls = fileManager.uploadFiles(images, "gym");
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.S3_UPLOAD_FAILED);
+        }
 
-		return imageUrls.stream()
-			.map(url -> GymImage.builder().url(url).build())
-			.toList();
-	}
+        return imageUrls.stream()
+            .map(url -> GymImage.builder().url(url).build())
+            .toList();
+    }
 
-	// 이미지 삭제 + 새 이미지 등록
-	private void updateImages(List<Long> deleteImageIds, List<MultipartFile> images, Gym gym) {
-		// 이미지 삭제 호출
-		if (deleteImageIds != null) {
-			deleteImages(deleteImageIds, gym);
-		}
+    // 이미지 삭제 + 새 이미지 등록
+    private void updateImages(List<Long> deleteImageIds, List<MultipartFile> images, Gym gym) {
+        // 이미지 삭제 호출
+        if (deleteImageIds != null) {
+            deleteImages(deleteImageIds, gym);
+        }
 
-		// 새 이미지 등록 호출
-		saveImages(images, gym);
-	}
+        // 새 이미지 등록 호출
+        saveImages(images, gym);
+    }
 
-	// 신규 이미지 저장
-	private void saveImages(List<MultipartFile> images, Gym gym) {
-		List<GymImage> gymImages = uploadAndMapImages(images);
-		gym.addImages(gymImages);
-	}
+    // 신규 이미지 저장
+    private void saveImages(List<MultipartFile> images, Gym gym) {
+        List<GymImage> gymImages = uploadAndMapImages(images);
+        gym.addImages(gymImages);
+    }
 
-	private void deleteImages(List<Long> deleteImageIds, Gym gym) {
-		// 삭제할 이미지 필터링
-		List<GymImage> imagesToDelete = gym.getImages().stream()
-			.filter(img -> deleteImageIds.contains(img.getGymImageId()))
-			.toList();
+    private void deleteImages(List<Long> deleteImageIds, Gym gym) {
+        // 삭제할 이미지 필터링
+        List<GymImage> imagesToDelete = gym.getImages().stream()
+            .filter(img -> deleteImageIds.contains(img.getGymImageId()))
+            .toList();
 
-		// S3 + 연관관계 제거
-		for (GymImage image : imagesToDelete) {
-			fileManager.deleteFile(image.getUrl());
-			gym.removeImage(image);
-		}
-	}
+        // S3 + 연관관계 제거
+        for (GymImage image : imagesToDelete) {
+            fileManager.deleteFile(image.getUrl());
+            gym.removeImage(image);
+        }
+    }
 
-	private void updateFacility(Gym existingGym, GymInfoRequest request) {
-		Facility facility = existingGym.getFacility();
-		facility.update(request.facilityRequest());
-	}
+    private void updateFacility(Gym existingGym, GymInfoRequest request) {
+        Facility facility = existingGym.getFacility();
+        facility.update(request.facilityRequest());
+    }
 
-	@Transactional(readOnly = true)
-	public List<PartnerGymNameProjection> getGymNamesByIds(Collection<Long> partnerGymIds) {
-		return partnerGymRepository.findGymNamesByPartnerGymIds(partnerGymIds);
-	}
+    @Transactional(readOnly = true)
+    public List<PartnerGymNameProjection> getGymNamesByIds(Collection<Long> partnerGymIds) {
+        return partnerGymRepository.findGymNamesByPartnerGymIds(partnerGymIds);
+    }
 }
 
 


### PR DESCRIPTION
# 📝 GymDetailResponse 에 gymProductResponses 추가 & Gym 엔티티에 updatePartner 메소드 추가

---

## 🔘 Part
- 도메인
gym
---

## 🔎 작업 내용
- PartnerGymService에서 updatePartner 호출
- 헬스장 단일 정보 조회시 이용권 정보 추가 
- gymId -> partnerGym -> gymProduct 를 통해 정보를 가져옵니다

---

## 🖼️ 이미지 첨부
![스크린샷 2025-04-08 오후 12 59 25](https://github.com/user-attachments/assets/761a9d59-f5bd-4866-b5a6-398d5ea6234d)

---

## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
