### PR TITLE
feat(award): 트레이너 award 더미 생성

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/dummycreate/processAwardForTrainer.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/dummycreate/processAwardForTrainer.java
@@ -1,0 +1,2 @@
+package org.helloworld.gymmate.domain.user.trainer.award.dummycreate;
+

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/entity/Award.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/entity/Award.java
@@ -1,10 +1,14 @@
 package org.helloworld.gymmate.domain.user.trainer.award.entity;
 
+import org.helloworld.gymmate.domain.user.trainer.entity.Trainer;
+
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
 import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
 import lombok.AllArgsConstructor;
@@ -19,20 +23,21 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(name = "award")
 public class Award {
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "award_id", nullable = false)
-	private Long awardId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "award_id", nullable = false)
+    private Long awardId;
 
-	@Column(name = "award_year", nullable = false)
-	private String awardYear;
+    @Column(name = "award_year", nullable = false)
+    private String awardYear;
 
-	@Column(name = "award_name", nullable = false)
-	private String awardName;
+    @Column(name = "award_name", nullable = false)
+    private String awardName;
 
-	@Column(name = "award_info", nullable = false)
-	private String awardInfo;
+    @Column(name = "award_info", nullable = false)
+    private String awardInfo;
 
-	@Column(name = "trainer_id", nullable = false)
-	private Long trainerId;
+    @ManyToOne
+    @JoinColumn(name = "trainer_id")
+    private Trainer trainer;
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/enums/AwardData.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/enums/AwardData.java
@@ -1,0 +1,29 @@
+package org.helloworld.gymmate.domain.user.trainer.award.enums;
+
+import lombok.Getter;
+
+@Getter
+public enum AwardData {
+    AWARD_1("2025", "WBFF KOREA(국제 아마추어전) 1등", "남자 일반부 - 체급별 1위"),
+    AWARD_2("2024", "서울특별시 보디빌딩 대회 1등", "남자 고등부 - 전체 1위"),
+    AWARD_3("2023", "전국 피트니스 챔피언십 1등", "남자 피지크 - 체급별 1위"),
+    AWARD_4("2025", "대한민국 클래식 보디빌딩 2등", "남자 마스터즈 - 체급별 2위"),
+    AWARD_5("2022", "부산광역시 스포츠대회 3등", "남자 피지크 - 전체 3위"),
+    AWARD_6("2023", "IFBB Korea 1등", "남자 피지크 - 체급별 1위"),
+    AWARD_7("2021", "인천 전국 보디빌딩 대회 3등", "남자 일반부 - 체급별 3위"),
+    AWARD_8("2025", "경기도 피트니스 페스티벌 1등", "남자 피지크 - 체급별 1위"),
+    AWARD_9("2024", "WBFF ASIA(국제 프로 & 아마추어전) 2등", "남자 일반부 - 전체 2위"),
+    AWARD_10("2023", "KBBF 보디빌딩 대회", "남자 일반부 - 전체 1위"),
+    AWARD_11("2022", "대구광역시 보디빌딩 선수권 2등", "남자 피지크 - 체급별 2위"),
+    AWARD_12("2021", "미스터제주 선발대회 1등", "남자 피지크 - 체급별 1위");
+
+    private final String awardYear;
+    private final String awardName;
+    private final String awardInfo;
+
+    AwardData(String awardYear, String awardName, String awardInfo) {
+        this.awardYear = awardYear;
+        this.awardName = awardName;
+        this.awardInfo = awardInfo;
+    }
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/entity/Trainer.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/entity/Trainer.java
@@ -9,6 +9,7 @@ import org.helloworld.gymmate.domain.gym.gyminfo.entity.Gym;
 import org.helloworld.gymmate.domain.pt.student.entity.Student;
 import org.helloworld.gymmate.domain.user.converter.GenderTypeConverter;
 import org.helloworld.gymmate.domain.user.enums.GenderType;
+import org.helloworld.gymmate.domain.user.trainer.award.entity.Award;
 import org.helloworld.gymmate.domain.user.trainer.dto.OwnerRegisterRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerModifyRequest;
 import org.helloworld.gymmate.domain.user.trainer.dto.TrainerProfileRequest;
@@ -112,6 +113,9 @@ public class Trainer {
     @OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, orphanRemoval = true)
     @Builder.Default
     private List<Student> students = new ArrayList<>();
+
+    @OneToMany(mappedBy = "trainer", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<Award> awards = new ArrayList<>(); //fetch = FetchType.LAZY??
 
     // ====== Business Logic ======
 

--- a/src/main/java/org/helloworld/gymmate/infra/domain/trainer/TrainerDummy.java
+++ b/src/main/java/org/helloworld/gymmate/infra/domain/trainer/TrainerDummy.java
@@ -1,0 +1,56 @@
+package org.helloworld.gymmate.infra.domain.trainer;
+
+import java.util.List;
+
+import org.helloworld.gymmate.domain.user.trainer.award.entity.Award;
+import org.helloworld.gymmate.domain.user.trainer.award.enums.AwardData;
+import org.helloworld.gymmate.domain.user.trainer.award.repository.AwardRepository;
+import org.helloworld.gymmate.domain.user.trainer.entity.Trainer;
+import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+public class TrainerDummy {
+
+    private final AwardRepository awardRepository;
+    private final TrainerRepository trainerRepository;
+
+    public TrainerDummy(AwardRepository awardRepository, TrainerRepository trainerRepository) {
+        this.awardRepository = awardRepository;
+        this.trainerRepository = trainerRepository;
+    }
+
+    @Transactional
+    public void processAwardsForTrainers(List<Trainer> trainers) {
+        if (trainers.isEmpty()) {
+            log.debug("저장할 트레이너 데이터가 없습니다.");
+            return;
+        }
+
+        for (Trainer trainer : trainers) {
+            // Enum에서 어워드 데이터 가져오기
+            for (AwardData awardData : AwardData.values()) {
+                // 빌더를 사용하여 Award 객체 생성
+                Award award = Award.builder()
+                    .awardYear(awardData.getAwardYear())
+                    .awardName(awardData.getAwardName())
+                    .awardInfo(awardData.getAwardInfo())
+                    .trainer(trainer) // 트레이너와의 관계 설정
+                    .build();
+
+                // 어워드 저장
+                awardRepository.save(award);
+
+                // 트레이너의 어워드 리스트에 추가
+                trainer.getAwards().add(award);
+            }
+
+            // 트레이너 업데이트 (어워드 리스트가 변경되었으므로)
+            trainerRepository.save(trainer); //명시적 저장?
+        }
+
+        log.debug("트레이너에 대한 어워드 데이터 저장 완료!");
+    }
+}


### PR DESCRIPTION
# 📝 제목
feat(award): 트레이너 award 더미 생성


## 🔎 작업 내용
- award 예시 12개 -> enum 타입 awardData에 저장
- award 와 trainer를 OneToMany,ManyToOne으로 연결
- infra/domain/trainer 폴더에 trainerDummy 파일 생성 
  -> trainer객체 리스트를 받아서 trainer객체와 award정보를 담은 award 객체를 생성해 저장
  -> trainer 레포지터리에도 award를 추가해 update 


## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 확인해줬으면 하는 부분

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
