### PR TITLE
feat(trainer):award 더미데이터 생성

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/enums/AwardData.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/enums/AwardData.java
@@ -1,0 +1,41 @@
+package org.helloworld.gymmate.domain.user.trainer.award.enums;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+
+import lombok.Getter;
+
+@Getter
+public enum AwardData {
+    AWARD_1("2025", "WBFF KOREA(국제 아마추어전) 1등", "남자 일반부 - 체급별 1위"),
+    AWARD_2("2024", "서울특별시 보디빌딩 대회 1등", "남자 고등부 - 전체 1위"),
+    AWARD_3("2023", "전국 피트니스 챔피언십 1등", "남자 피지크 - 체급별 1위"),
+    AWARD_4("2025", "대한민국 클래식 보디빌딩 2등", "남자 마스터즈 - 체급별 2위"),
+    AWARD_5("2022", "부산광역시 스포츠대회 3등", "남자 피지크 - 전체 3위"),
+    AWARD_6("2023", "IFBB Korea 1등", "남자 피지크 - 체급별 1위"),
+    AWARD_7("2021", "인천 전국 보디빌딩 대회 3등", "남자 일반부 - 체급별 3위"),
+    AWARD_8("2025", "경기도 피트니스 페스티벌 1등", "남자 피지크 - 체급별 1위"),
+    AWARD_9("2024", "WBFF ASIA(국제 프로 & 아마추어전) 2등", "남자 일반부 - 전체 2위"),
+    AWARD_10("2023", "KBBF 보디빌딩 대회", "남자 일반부 - 전체 1위"),
+    AWARD_11("2022", "대구광역시 보디빌딩 선수권 2등", "남자 피지크 - 체급별 2위"),
+    AWARD_12("2021", "미스터제주 선발대회 1등", "남자 피지크 - 체급별 1위");
+
+    private final String awardYear;
+    private final String awardName;
+    private final String awardInfo;
+
+    AwardData(String awardYear, String awardName, String awardInfo) {
+        this.awardYear = awardYear;
+        this.awardName = awardName;
+        this.awardInfo = awardInfo;
+    }
+
+    //'count'개의 랜덤한 AwardData리스트를 반환
+    public static List<AwardData> getRandomAwards(int count) {
+        List<AwardData> allAwards = new ArrayList<>(Arrays.asList(values()));
+        Collections.shuffle(allAwards);
+        return allAwards.subList(0, Math.min(count, allAwards.size()));
+    }
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/mapper/AwardMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/award/mapper/AwardMapper.java
@@ -1,0 +1,16 @@
+package org.helloworld.gymmate.domain.user.trainer.award.mapper;
+
+import org.helloworld.gymmate.domain.user.trainer.award.entity.Award;
+import org.helloworld.gymmate.domain.user.trainer.award.enums.AwardData;
+
+public class AwardMapper {
+
+    public static Award toEntity(AwardData awardData, Long trainerId) {
+        return Award.builder()
+            .awardYear(awardData.getAwardYear())
+            .awardName(awardData.getAwardName())
+            .awardInfo(awardData.getAwardInfo())
+            .trainerId(trainerId)
+            .build();
+    }
+}

--- a/src/main/java/org/helloworld/gymmate/infra/domain/trainer/TrainerDummy.java
+++ b/src/main/java/org/helloworld/gymmate/infra/domain/trainer/TrainerDummy.java
@@ -1,0 +1,73 @@
+package org.helloworld.gymmate.infra.domain.trainer;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import org.helloworld.gymmate.domain.user.trainer.award.entity.Award;
+import org.helloworld.gymmate.domain.user.trainer.award.enums.AwardData;
+import org.helloworld.gymmate.domain.user.trainer.award.mapper.AwardMapper;
+import org.helloworld.gymmate.domain.user.trainer.award.repository.AwardRepository;
+import org.helloworld.gymmate.domain.user.trainer.entity.Trainer;
+import org.helloworld.gymmate.domain.user.trainer.repository.TrainerRepository;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@RequiredArgsConstructor
+@Slf4j
+public class TrainerDummy {
+
+    private static final int BATCH_SIZE = 500;
+    private final JdbcTemplate jdbcTemplate;
+    private final AwardRepository awardRepository;
+    private final TrainerRepository trainerRepository;
+
+    @Transactional
+    public void processAwardsForTrainers(List<Trainer> trainers) {
+        if (trainers.isEmpty()) {
+            log.debug("저장할 트레이너 데이터가 없습니다.");
+            return;
+        }
+        //db에 insert할 award 리스트
+        List<Award> awardsToInsert = new ArrayList<>();
+
+        //트레이너마다 랜덤한 award 3개 생성
+        for (Trainer trainer : trainers) {
+            // Enum에서 AwardData3개 가져오기
+            List<AwardData> selectedAwards = AwardData.getRandomAwards(3);
+
+            for (AwardData awardData : selectedAwards) { // 각 어워드마다
+
+                Award award = AwardMapper.toEntity(awardData, trainer.getTrainerId()); // Award 객체 생성
+
+                awardsToInsert.add(award); // 리스트에 어워드 저장
+
+                //awardRepository.save(award);
+
+            }
+        }
+
+        // award INSERT 쿼리 ( year, name, info, trainer 정보 )
+        String sql =
+            "Insert into award (award_year, award_name, award_info, trainer_id) "
+                + "values (?, ?, ? ,?)";
+        try {
+            jdbcTemplate.batchUpdate(sql, awardsToInsert, BATCH_SIZE, (ps, award) -> {
+                //awardsToInsert의 award객체를 꺼내서 sql의 '?'부분의 값 설정
+                ps.setString(1, award.getAwardYear());
+                ps.setString(2, award.getAwardName());
+                ps.setString(3, award.getAwardInfo());
+                ps.setLong(4, award.getTrainerId());
+            });
+
+            log.debug("총 {}개의 award 데이터 저장 완료!", awardsToInsert.size());
+
+        } catch (Exception e) {
+
+            log.error("award 데이터 저장 중 오류 발생: ", e);
+        }
+
+    }
+}


### PR DESCRIPTION
# 📝 제목
refactor(trainer):award 더미데이터 생성


## 🔎 작업 내용
- award 예시 12개 -> enum 타입 awardData에 저장
- infra/domain/trainer 폴더에 trainerDummy 파일 생성 
  - trainer객체 리스트를 받아서 trainerid와 award정보(name,year,info)를 담은 award 객체를 생성해 리스트에 저장 후 나중에 sql insert문 실행
  - sql, jdbcTemplate사용 
- 재현님 코드를 보고 비슷하게 작성하였습니다!

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항

---

## 🔧 앞으로의 과제

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
