### PR TITLE
refactor(myself) : member recent 기록 갱신 로직 추가

### DIFF
--- a/src/main/java/org/helloworld/gymmate/common/exception/ErrorCode.java
+++ b/src/main/java/org/helloworld/gymmate/common/exception/ErrorCode.java
@@ -7,84 +7,85 @@ import lombok.Getter;
 @Getter
 public enum ErrorCode {
 
-	USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저를 찾을 수 없습니다."),
-	USER_LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "USER-002", "로그인이 필요합니다."),
-	USER_NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "USER-003", "닉네임이 중복 되었습니다."),
-	INSUFFICIENT_CASH(HttpStatus.NOT_FOUND, "USER-004", "캐시가 부족합니다."),
-	TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "TOKEN-001", "토큰이 유효하지 않습니다."),
-	REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW-001", "리뷰를 찾을 수 없습니다."),
-	REVIEW_PERMISSION_DENIED(HttpStatus.UNAUTHORIZED, "REVIEW-002", "리뷰에 대한 삭제/수정 권한이 없습니다."),
-	INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL-001", "서버 내부 오류"),
-	PAYLOAD_TOO_LARGE(HttpStatus.BAD_REQUEST, "PAYLOAD-001", "파일 크기가 제한을 초과했습니다. (최대 10MB)"),
-	FILE_UPLOAD_TYPE_ERROR(HttpStatus.BAD_REQUEST, "FILE-001", "이미지파일 이외의 업로드는 불가능합니다."),
-	FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-002", "파일 업로드 중 오류가 발생했습니다."),
-	FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-003", "파일 삭제 중 오류가 발생했습니다."),
-	DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-004", "디렉토리 생성 중 오류가 발생했습니다."),
-	INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "PARAMETER-001", "요청 파라미터가 유효하지 않습니다."),
-	INVALID_BUSINESS_NUMBER(HttpStatus.BAD_REQUEST, "BUSINESS-001", "사업자 등록번호가 유효하지 않습니다."),
+    USER_NOT_FOUND(HttpStatus.NOT_FOUND, "USER-001", "유저를 찾을 수 없습니다."),
+    USER_LOGIN_REQUIRED(HttpStatus.UNAUTHORIZED, "USER-002", "로그인이 필요합니다."),
+    USER_NICKNAME_DUPLICATION(HttpStatus.BAD_REQUEST, "USER-003", "닉네임이 중복 되었습니다."),
+    INSUFFICIENT_CASH(HttpStatus.NOT_FOUND, "USER-004", "캐시가 부족합니다."),
+    TOKEN_NOT_VALID(HttpStatus.UNAUTHORIZED, "TOKEN-001", "토큰이 유효하지 않습니다."),
+    REVIEW_NOT_FOUND(HttpStatus.NOT_FOUND, "REVIEW-001", "리뷰를 찾을 수 없습니다."),
+    REVIEW_PERMISSION_DENIED(HttpStatus.UNAUTHORIZED, "REVIEW-002", "리뷰에 대한 삭제/수정 권한이 없습니다."),
+    INTERNAL_SERVER_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "INTERNAL-001", "서버 내부 오류"),
+    PAYLOAD_TOO_LARGE(HttpStatus.BAD_REQUEST, "PAYLOAD-001", "파일 크기가 제한을 초과했습니다. (최대 10MB)"),
+    FILE_UPLOAD_TYPE_ERROR(HttpStatus.BAD_REQUEST, "FILE-001", "이미지파일 이외의 업로드는 불가능합니다."),
+    FILE_UPLOAD_ERROR(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-002", "파일 업로드 중 오류가 발생했습니다."),
+    FILE_DELETE_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-003", "파일 삭제 중 오류가 발생했습니다."),
+    DIRECTORY_CREATION_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "FILE-004", "디렉토리 생성 중 오류가 발생했습니다."),
+    INVALID_PARAMETER(HttpStatus.BAD_REQUEST, "PARAMETER-001", "요청 파라미터가 유효하지 않습니다."),
+    INVALID_BUSINESS_NUMBER(HttpStatus.BAD_REQUEST, "BUSINESS-001", "사업자 등록번호가 유효하지 않습니다."),
 
-	// PT
-	CLASSTIME_DUPLICATED(HttpStatus.BAD_REQUEST, "PT-CLASSTIME-001", "이미 등록된 수업 시간입니다."),
-	CLASSTIME_NOT_FOUND(HttpStatus.NOT_FOUND, "PT-CLASSTIME-002", "존재하지 않는 PT 수강 가능 시간입니다."),
-	PTPRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PT-PRODUCT-001", "존재하지 않는 PT 수업입니다."),
-	UNSUPPORTED_SEARCH_OPTION(HttpStatus.BAD_REQUEST, "PT-PRODUCT-002", "존재하지 않는 검색 옵션입니다."),
-	UNSUPPORTED_SORT_OPTION(HttpStatus.BAD_REQUEST, "PT-PRODUCT-003", "존재하지 않는 정렬 조건입니다."),
+    // PT
+    CLASSTIME_DUPLICATED(HttpStatus.BAD_REQUEST, "PT-CLASSTIME-001", "이미 등록된 수업 시간입니다."),
+    CLASSTIME_NOT_FOUND(HttpStatus.NOT_FOUND, "PT-CLASSTIME-002", "존재하지 않는 PT 수강 가능 시간입니다."),
+    PTPRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "PT-PRODUCT-001", "존재하지 않는 PT 수업입니다."),
+    UNSUPPORTED_SEARCH_OPTION(HttpStatus.BAD_REQUEST, "PT-PRODUCT-002", "존재하지 않는 검색 옵션입니다."),
+    UNSUPPORTED_SORT_OPTION(HttpStatus.BAD_REQUEST, "PT-PRODUCT-003", "존재하지 않는 정렬 조건입니다."),
 
-	// Student
-	STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PT-PRODUCT-001", "존재하지 않는 수강생입니다."),
+    // Student
+    STUDENT_NOT_FOUND(HttpStatus.NOT_FOUND, "PT-PRODUCT-001", "존재하지 않는 수강생입니다."),
 
-	//reservation
-	RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION-001", "예약이 존재하지 않습니다"),
-	CANNOT_CANCEL_THIS_WEEK_RESERVATION(HttpStatus.BAD_REQUEST, "RESERVATION-002", "이번 주 예약은 취소할 수 없습니다."),
+    //reservation
+    RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "RESERVATION-001", "예약이 존재하지 않습니다"),
+    CANNOT_CANCEL_THIS_WEEK_RESERVATION(HttpStatus.BAD_REQUEST, "RESERVATION-002", "이번 주 예약은 취소할 수 없습니다."),
 
-	// Gym
-	GYM_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "GYM-001", "잘못된 입력값입니다."),
-	GYM_NOT_FOUND(HttpStatus.NOT_FOUND, "GYM-002", "요청한 헬스장이 존재하지 않습니다."),
-	GYM_ALREADY_EXISTS(HttpStatus.CONFLICT, "GYM-003", "이미 등록된 헬스장입니다."),
-	GYM_REGISTRATION_FORBIDDEN(HttpStatus.FORBIDDEN, "GYM-004", "헬스장 등록 권한이 없습니다."),
-	GYM_FORBIDDEN(HttpStatus.FORBIDDEN, "GYM-005", "해당 헬스장에 대한 수정 권한이 없습니다."),
+    // Gym
+    GYM_INVALID_REQUEST(HttpStatus.BAD_REQUEST, "GYM-001", "잘못된 입력값입니다."),
+    GYM_NOT_FOUND(HttpStatus.NOT_FOUND, "GYM-002", "요청한 헬스장이 존재하지 않습니다."),
+    GYM_ALREADY_EXISTS(HttpStatus.CONFLICT, "GYM-003", "이미 등록된 헬스장입니다."),
+    GYM_REGISTRATION_FORBIDDEN(HttpStatus.FORBIDDEN, "GYM-004", "헬스장 등록 권한이 없습니다."),
+    GYM_FORBIDDEN(HttpStatus.FORBIDDEN, "GYM-005", "해당 헬스장에 대한 수정 권한이 없습니다."),
 
-	// PartnerGym
-	PARTNER_GYM_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTNER-GYM-001", "파트너 헬스장이 등록되어 있지 않습니다."),
+    // PartnerGym
+    PARTNER_GYM_NOT_FOUND(HttpStatus.NOT_FOUND, "PARTNER-GYM-001", "파트너 헬스장이 등록되어 있지 않습니다."),
 
-	// GymProduct
-	GYMPRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "GYM-PRODUCT-001", "존재하지 않는 헬스장 이용권입니다."),
-	GYMPRODUCT_PARTNER_MISMATCH(HttpStatus.BAD_REQUEST, "GYM-PRODUCT-002", "해당 이용권은 이 파트너 헬스장에 속하지 않습니다."),
+    // GymProduct
+    GYMPRODUCT_NOT_FOUND(HttpStatus.NOT_FOUND, "GYM-PRODUCT-001", "존재하지 않는 헬스장 이용권입니다."),
+    GYMPRODUCT_PARTNER_MISMATCH(HttpStatus.BAD_REQUEST, "GYM-PRODUCT-002", "해당 이용권은 이 파트너 헬스장에 속하지 않습니다."),
 
-	// GymTicket
-	GYM_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "GYM-TICKET-001", "존재하지 않는 헬스장 이용권입니다."),
+    // GymTicket
+    GYM_TICKET_NOT_FOUND(HttpStatus.NOT_FOUND, "GYM-TICKET-001", "존재하지 않는 헬스장 이용권입니다."),
 
-	// Machine
-	MACHINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MACHINE-001", "해당 기구가 존재하지 않습니다."),
-	MACHINE_FORBIDDEN(HttpStatus.FORBIDDEN, "MACHINE-002", "해당 기구에 대한 권한이 없습니다."),
-	MACHINE_MAX_UPLOAD(HttpStatus.FORBIDDEN, "MACHINE-003", "기구정보는 최대 30개 등록 가능합니다."),
+    // Machine
+    MACHINE_NOT_FOUND(HttpStatus.NOT_FOUND, "MACHINE-001", "해당 기구가 존재하지 않습니다."),
+    MACHINE_FORBIDDEN(HttpStatus.FORBIDDEN, "MACHINE-002", "해당 기구에 대한 권한이 없습니다."),
+    MACHINE_MAX_UPLOAD(HttpStatus.FORBIDDEN, "MACHINE-003", "기구정보는 최대 30개 등록 가능합니다."),
 
-	// Myself
-	BIGTHREE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-BIGTHREE-001", "해당 3대 측정 기록을 찾을 수 없습니다."),
-	DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-RECORD-001", "해당 운동 기록을 찾을 수 없습니다."),
+    // Myself
+    BIGTHREE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-BIGTHREE-001", "해당 3대 측정 기록을 찾을 수 없습니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-RECORD-001", "해당 운동 기록을 찾을 수 없습니다."),
+    BIGTHREE_AVERAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BIGTHREE-AVG-001", "3대 측정 평균 기록을 찾을 수 없습니다."),
 
-	// 인증 관련
-	AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증이 필요합니다. 로그인 후 다시 시도해주세요."),
-	USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "AUTH-002", "권한이 부족합니다."),
+    // 인증 관련
+    AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증이 필요합니다. 로그인 후 다시 시도해주세요."),
+    USER_NOT_AUTHORIZED(HttpStatus.FORBIDDEN, "AUTH-002", "권한이 부족합니다."),
 
-	// 이미지 관련
-	IMAGE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "IMAGE-002", "업로드한 파일 크기가 너무 큽니다. 최대 5MB까지 가능합니다."),
-	IMAGE_UNSUPPORTED_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "IMAGE-003", "지원되지 않는 파일 형식입니다. (jpg, png, gif만 가능)"),
+    // 이미지 관련
+    IMAGE_TOO_LARGE(HttpStatus.PAYLOAD_TOO_LARGE, "IMAGE-002", "업로드한 파일 크기가 너무 큽니다. 최대 5MB까지 가능합니다."),
+    IMAGE_UNSUPPORTED_TYPE(HttpStatus.UNSUPPORTED_MEDIA_TYPE, "IMAGE-003", "지원되지 않는 파일 형식입니다. (jpg, png, gif만 가능)"),
 
-	// S3 관련
-	S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3-001", "이미지 업로드 중 오류가 발생했습니다. 다시 시도해주세요."),
+    // S3 관련
+    S3_UPLOAD_FAILED(HttpStatus.INTERNAL_SERVER_ERROR, "S3-001", "이미지 업로드 중 오류가 발생했습니다. 다시 시도해주세요."),
 
-	// API 관련
-	API_UNEXPECTED_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "API-001", "API 응답이 올바르지 않습니다.");
+    // API 관련
+    API_UNEXPECTED_RESPONSE(HttpStatus.INTERNAL_SERVER_ERROR, "API-001", "API 응답이 올바르지 않습니다.");
 
-	private final HttpStatus httpStatus;
-	private final String errorCode;
-	private final String message;
+    private final HttpStatus httpStatus;
+    private final String errorCode;
+    private final String message;
 
-	ErrorCode(HttpStatus httpStatus, String errorCode, String message) {
-		this.httpStatus = httpStatus;
-		this.errorCode = errorCode;
-		this.message = message;
-	}
+    ErrorCode(HttpStatus httpStatus, String errorCode, String message) {
+        this.httpStatus = httpStatus;
+        this.errorCode = errorCode;
+        this.message = message;
+    }
 }
 

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/controller/BigthreeController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/controller/BigthreeController.java
@@ -1,15 +1,24 @@
 package org.helloworld.gymmate.domain.myself.bigthree.controller;
 
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeStatsResponse;
 import org.helloworld.gymmate.domain.myself.bigthree.service.BigthreeService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/bigthree")
@@ -19,16 +28,17 @@ public class BigthreeController {
 
     @PostMapping
     public ResponseEntity<Long> createBigthree(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @Valid @RequestBody BigthreeCreateRequest request) {
-        
-        return ResponseEntity.status(HttpStatus.CREATED).body(bigthreeService.createBigthree(request, customOAuth2User.getUserId()));
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @Valid @RequestBody BigthreeCreateRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(bigthreeService.createBigthree(request, customOAuth2User.getUserId()));
     }
 
     @DeleteMapping(value = "/{bigthreeId}")
     public ResponseEntity<Void> deleteBigthree(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @PathVariable Long bigthreeId) {
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @PathVariable Long bigthreeId) {
 
         bigthreeService.deleteBigthree(bigthreeId, customOAuth2User.getUserId());
 
@@ -37,13 +47,22 @@ public class BigthreeController {
 
     @PutMapping(value = "/{bigthreeId}")
     public ResponseEntity<Void> modifyBigthree(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @PathVariable Long bigthreeId,
-            @Valid @RequestBody BigthreeRequest request) {
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @PathVariable Long bigthreeId,
+        @Valid @RequestBody BigthreeRequest request) {
 
         bigthreeService.modifyBigthree(bigthreeId, request, customOAuth2User.getUserId());
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/status")
+    public ResponseEntity<BigthreeStatsResponse> getBigthreeStats(
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ) {
+        BigthreeStatsResponse response = bigthreeService.getBigthreeStats(customOAuth2User.getUserId());
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeStatsResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeStatsResponse.java
@@ -1,0 +1,19 @@
+package org.helloworld.gymmate.domain.myself.bigthree.dto;
+
+public record BigthreeStatsResponse(
+    int mostLevel,            // 가장 많은 일반 회원이 속한 레벨
+    double sumAverage,        // 전체 일반 회원의 3대 합산 평균
+    double benchAverage,      // 벤치프레스 평균
+    double deadliftAverage,   // 데드리프트 평균
+    double squatAverage,      // 스쿼트 평균
+
+    double recentBench,       // 내 최근 벤치 무게
+    double recentDeadlift,    // 내 최근 데드리프트 무게
+    double recentSquat,       // 내 최근 스쿼트 무게
+    double myAvg,            //(추가)사용자의 3대 평균
+
+    double benchRate,            //벤치 비율
+    double deadliftRate,         //데드리프트 비율
+    double squatRate            //스쿼트 비율
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/entity/Bigthree.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/entity/Bigthree.java
@@ -50,4 +50,10 @@ public class Bigthree {
 
     // ====== Business Logic ======
 
+    public void update(double bench, double deadlift, double squat) {
+        this.bench = bench;
+        this.deadlift = deadlift;
+        this.squat = squat;
+    }
+
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/mapper/BigthreeMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/mapper/BigthreeMapper.java
@@ -1,12 +1,16 @@
 package org.helloworld.gymmate.domain.myself.bigthree.mapper;
 
-import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
-import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
-import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
-import org.helloworld.gymmate.domain.user.member.entity.Member;
-
 import java.time.LocalDate;
 
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeStatsResponse;
+import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
 public class BigthreeMapper {
     public static Bigthree toEntity(BigthreeCreateRequest request, Member member, LocalDate date) {
         return toEntity(request.bigthreeRequest(), member, date);
@@ -14,11 +18,38 @@ public class BigthreeMapper {
 
     public static Bigthree toEntity(BigthreeRequest request, Member member, LocalDate date) {
         return Bigthree.builder()
-                .bench(request.bench())
-                .deadlift(request.deadlift())
-                .squat(request.squat())
-                .date(date)
-                .member(member)
-                .build();
+            .bench(request.bench())
+            .deadlift(request.deadlift())
+            .squat(request.squat())
+            .date(date)
+            .member(member)
+            .build();
+    }
+
+    public BigthreeStatsResponse toResponseDto(
+        Member member,
+        BigthreeAverage average,
+        int mostLevel,
+        double benchRate,
+        double deadliftRate,
+        double squatRate,
+        double myAvg
+    ) {
+        return new BigthreeStatsResponse(
+            mostLevel,
+            average.getSumAverage(),
+            average.getBenchAverage(),
+            average.getDeadliftAverage(),
+            average.getSquatAverage(),
+
+            member.getRecentBench(),
+            member.getRecentDeadlift(),
+            member.getRecentSquat(),
+            myAvg,
+
+            benchRate,
+            deadliftRate,
+            squatRate
+        );
     }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/repository/BigthreeRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/repository/BigthreeRepository.java
@@ -1,9 +1,15 @@
 package org.helloworld.gymmate.domain.myself.bigthree.repository;
 
+import java.util.Optional;
+
 import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BigthreeRepository extends JpaRepository<Bigthree, Long> {
+
+    // 3대 등록을 같은 날 여러번 한 경우, 더 나중에 등록된 기록을 우선
+    Optional<Bigthree> findTopByMemberOrderByDateDescBigthreeIdDesc(Member member);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
@@ -1,26 +1,34 @@
 package org.helloworld.gymmate.domain.myself.bigthree.service;
 
-import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDate;
+
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeStatsResponse;
 import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
 import org.helloworld.gymmate.domain.myself.bigthree.mapper.BigthreeMapper;
 import org.helloworld.gymmate.domain.myself.bigthree.repository.BigthreeRepository;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.repository.BigthreeAverageRepository;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.helloworld.gymmate.domain.user.member.repository.MemberRepository;
 import org.helloworld.gymmate.domain.user.member.service.MemberService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class BigthreeService {
     private final BigthreeRepository bigthreeRepository;
     private final MemberService memberService;
+    private final BigthreeAverageRepository bigthreeAverageRepository;
+    private final BigthreeMapper bigthreeMapper;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public long createBigthree(@Valid BigthreeCreateRequest request, Long memberId) {
@@ -62,7 +70,7 @@ public class BigthreeService {
     private Bigthree getExistingBigthree(Long bigthreeId) {
         //기존 3대 측정 기록 가져오기
         return bigthreeRepository.findById(bigthreeId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND));
     }
 
     private void validateBigthreeOwner(Bigthree bigthree, Member member) {
@@ -72,4 +80,49 @@ public class BigthreeService {
         }
     }
 
+    //TODO: Bigthree 테이블에 저장된 기록 중 가장 최신값 회원의  recent필드에 업데이트하는 로직
+
+    // 3대 측정 통계
+    @Transactional(readOnly = true)
+    public BigthreeStatsResponse getBigthreeStats(Long memberId) {
+        Member member = getMember(memberId);
+
+        if (member.getRecentBench() == null || member.getRecentDeadlift() == null || member.getRecentSquat() == null) {
+            throw new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND);
+        }
+
+        BigthreeAverage average = getLatestBigthreeAverage();
+        int mostLevel = getMostLevel();
+        double myTotal = member.getRecentBench() + member.getRecentDeadlift() + member.getRecentSquat();
+
+        double benchRate = calculateRate(member.getRecentBench(), myTotal);
+        double deadliftRate = calculateRate(member.getRecentDeadlift(), myTotal);
+        double squatRate = calculateRate(member.getRecentSquat(), myTotal);
+
+        double myAvg = myTotal / 3.0;
+
+        return bigthreeMapper.toResponseDto(member, average, mostLevel, benchRate, deadliftRate, squatRate, myAvg);
+    }
+
+    private double calculateRate(Double myWeight, Double myTotal) {
+        if (myTotal == null || myTotal == 0.0)
+            return 0;
+
+        // 비율 계산 후 소수점 둘째자리까지 반올림
+        double rawRate = (myWeight / myTotal) * 100;
+        return Math.round(rawRate * 100.0) / 100.0;
+    }
+
+    private BigthreeAverage getLatestBigthreeAverage() {
+        // 3대 측정 평균 가져오기
+        return bigthreeAverageRepository.findTopByOrderByBigthreeAverageIdDesc()
+            .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_AVERAGE_NOT_FOUND));
+    }
+
+    private int getMostLevel() {
+        // 많은 일반 회원이 속한 레벨 가져오기
+        return memberRepository.findMostLevel();
+    }
+
 }
+

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/entity/BigthreeAverage.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/entity/BigthreeAverage.java
@@ -1,0 +1,39 @@
+package org.helloworld.gymmate.domain.myself.bigthreeaverage.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "bigthree_average")
+public class BigthreeAverage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bigthree_average_id")
+    private Long bigthreeAverageId;
+
+    @Column(name = "sum_average", nullable = false)
+    private double sumAverage;
+
+    @Column(name = "bench_average", nullable = false)
+    private double benchAverage;
+
+    @Column(name = "deadlift_average", nullable = false)
+    private double deadliftAverage;
+
+    @Column(name = "squat_average", nullable = false)
+    private double squatAverage;
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/repository/BigthreeAverageRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/repository/BigthreeAverageRepository.java
@@ -1,0 +1,10 @@
+package org.helloworld.gymmate.domain.myself.bigthreeaverage.repository;
+
+import java.util.Optional;
+
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BigthreeAverageRepository extends JpaRepository<BigthreeAverage, Long> {
+    Optional<BigthreeAverage> findTopByOrderByBigthreeAverageIdDesc();
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/scheduler/BigthreeAverageScheduler.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/scheduler/BigthreeAverageScheduler.java
@@ -1,0 +1,71 @@
+package org.helloworld.gymmate.domain.myself.bigthreeaverage.scheduler;
+
+import java.util.List;
+
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.repository.BigthreeAverageRepository;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.helloworld.gymmate.domain.user.member.repository.MemberRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BigthreeAverageScheduler {
+
+    private final MemberRepository memberRepository;
+    private final BigthreeAverageRepository bigthreeAverageRepository;
+
+    @Scheduled(cron = "0 0 0  * * *") //매일 자정 실행
+    @Transactional
+    public void updateBigthreeAverage() {
+        // 최근 벤치, 데드리프트, 스쿼트 값이 모두 있는 일반 회원 조회
+        List<Member> members = memberRepository.findAllWithRecentBigthree();
+
+        if (members.isEmpty()) {
+            log.debug("3대 평균 계산을 위한 일반 회원 데이터가 없습니다.");
+            return;
+        }
+
+        double totalBench = 0, totalDeadlift = 0, totalSquat = 0, totalSum = 0;
+        for (Member m : members) {
+            double bench = m.getRecentBench();
+            double deadlift = m.getRecentDeadlift();
+            double squat = m.getRecentSquat();
+
+            totalBench += bench;
+            totalDeadlift += deadlift;
+            totalSquat += squat;
+
+            totalSum += bench + deadlift + squat;
+        }
+
+        int count = members.size();
+        double benchAvg = roundTo2(totalBench / count);
+        double deadliftAvg = roundTo2(totalDeadlift / count);
+        double squatAvg = roundTo2(totalSquat / count);
+        double sumAvg = roundTo2(totalSum / count);
+
+        BigthreeAverage average = BigthreeAverage.builder()
+            .benchAverage(benchAvg)
+            .deadliftAverage(deadliftAvg)
+            .squatAverage(squatAvg)
+            .sumAverage(sumAvg)
+            .build();
+
+        bigthreeAverageRepository.save(average);
+        log.debug("3대 평균 저장 완료 : bench={}, deadlift={}, squat={}, sum={}",
+            benchAvg, deadliftAvg, squatAvg, sumAvg);
+    }
+
+    // 소수점 둘째 자리까지 반올림해서 DB에 저장
+    private double roundTo2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
@@ -35,113 +35,120 @@ import lombok.NoArgsConstructor;
 @Table(name = "gymmate_member")
 public class Member {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "member_id")
-	private Long memberId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
 
-	@Column(name = "phone_number", unique = true)
-	private String phoneNumber;
+    @Column(name = "phone_number", unique = true)
+    private String phoneNumber;
 
-	@Column(name = "member_name")
-	private String memberName;
+    @Column(name = "member_name")
+    private String memberName;
 
-	@Column(name = "email")
-	private String email;
+    @Column(name = "email")
+    private String email;
 
-	@Column(name = "birthday")
-	private String birthday;
+    @Column(name = "birthday")
+    private String birthday;
 
-	@Convert(converter = GenderTypeConverter.class)
-	@Column(name = "gender_type")
-	private GenderType genderType;
+    @Convert(converter = GenderTypeConverter.class)
+    @Column(name = "gender_type")
+    private GenderType genderType;
 
-	@Column(name = "height")
-	private String height; //신체정보
+    @Column(name = "height")
+    private String height; //신체정보
 
-	@Column(name = "weight")
-	private String weight;
+    @Column(name = "weight")
+    private String weight;
 
-	@Column(name = "address")
-	private String address; //주소
+    @Column(name = "address")
+    private String address; //주소
 
-	@Column(name = "x_field")
-	private Double xField;
+    @Column(name = "x_field")
+    private Double xField;
 
-	@Column(name = "y_field")
-	private Double yField;
+    @Column(name = "y_field")
+    private Double yField;
 
-	@Column(name = "recent_bench")
-	private Double recentBench; //3대 - 밴치프레스
+    @Column(name = "recent_bench")
+    private Double recentBench; //3대 - 밴치프레스
 
-	@Column(name = "recent_deadlift")
-	private Double recentDeadlift; //3대 - 데드리프트
+    @Column(name = "recent_deadlift")
+    private Double recentDeadlift; //3대 - 데드리프트
 
-	@Column(name = "recent_squat")
-	private Double recentSquat; //3대 - 스쿼트
+    @Column(name = "recent_squat")
+    private Double recentSquat; //3대 - 스쿼트
 
-	@Column(name = "level")
-	private Integer level; //3대 - 레벨
+    @Column(name = "level")
+    private Integer level; //3대 - 레벨
 
-	@Column(name = "profile_url")
-	private String profileUrl;
+    @Column(name = "profile_url")
+    private String profileUrl;
 
-	@Column(name = "is_account_nonlocked")
-	private Boolean isAccountNonLocked; //계정잠김여부
+    @Column(name = "is_account_nonlocked")
+    private Boolean isAccountNonLocked; //계정잠김여부
 
-	@Column(name = "additional_info_completed")
-	private Boolean additionalInfoCompleted; // 추가 정보 입력 여부
+    @Column(name = "additional_info_completed")
+    private Boolean additionalInfoCompleted; // 추가 정보 입력 여부
 
-	@Column(name = "cash")
-	private Long cash;
+    @Column(name = "cash")
+    private Long cash;
 
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-	@JoinColumn(name = "oauth_id")
-	private Oauth oauth;
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "oauth_id")
+    private Oauth oauth;
 
-	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<GymTicket> gymTickets = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<GymTicket> gymTickets = new ArrayList<>();
 
-	// ====== Business Logic ======
+    // ====== Business Logic ======
 
-	public void registerMemberInfo(MemberRequest request) {
-		this.phoneNumber = request.phoneNumber();
-		this.memberName = request.memberName();
-		this.email = request.email();
-		this.birthday = request.birthday();
-		this.genderType = GenderType.fromString(request.gender());
-		this.height = request.height();
-		this.weight = request.weight();
-		this.address = request.address();
-		this.xField = request.xField();
-		this.yField = request.yField();
-		this.recentBench = request.recentBench();
-		this.recentDeadlift = request.recentDeadlift();
-		this.recentSquat = request.recentSquat();
-		this.additionalInfoCompleted = true;
+    public void registerMemberInfo(MemberRequest request) {
+        this.phoneNumber = request.phoneNumber();
+        this.memberName = request.memberName();
+        this.email = request.email();
+        this.birthday = request.birthday();
+        this.genderType = GenderType.fromString(request.gender());
+        this.height = request.height();
+        this.weight = request.weight();
+        this.address = request.address();
+        this.xField = request.xField();
+        this.yField = request.yField();
+        this.recentBench = request.recentBench();
+        this.recentDeadlift = request.recentDeadlift();
+        this.recentSquat = request.recentSquat();
+        this.additionalInfoCompleted = true;
 
-	}
+    }
 
-	public void modifyMemberInfo(MemberRequest request, String profileUrl) {
-		this.phoneNumber = request.phoneNumber();
-		this.memberName = request.memberName();
-		this.email = request.email();
-		this.birthday = request.birthday();
-		this.genderType = GenderType.fromString(request.gender());
-		this.height = request.height();
-		this.weight = request.weight();
-		this.address = request.address();
-		this.xField = request.xField();
-		this.yField = request.yField();
-		this.recentBench = request.recentBench();
-		this.recentDeadlift = request.recentDeadlift();
-		this.recentSquat = request.recentSquat();
-		this.profileUrl = profileUrl;
-		this.additionalInfoCompleted = true;
-	}
+    public void modifyMemberInfo(MemberRequest request, String profileUrl) {
+        this.phoneNumber = request.phoneNumber();
+        this.memberName = request.memberName();
+        this.email = request.email();
+        this.birthday = request.birthday();
+        this.genderType = GenderType.fromString(request.gender());
+        this.height = request.height();
+        this.weight = request.weight();
+        this.address = request.address();
+        this.xField = request.xField();
+        this.yField = request.yField();
+        this.recentBench = request.recentBench();
+        this.recentDeadlift = request.recentDeadlift();
+        this.recentSquat = request.recentSquat();
+        this.profileUrl = profileUrl;
+        this.additionalInfoCompleted = true;
+    }
 
-	public void updateCash(Long updateCash) {
-		this.cash = updateCash;
-	}
+    public void updateCash(Long updateCash) {
+        this.cash = updateCash;
+    }
+
+    public void updateRecentBigthree(double bench, double deadlift, double squat) {
+        this.recentBench = bench;
+        this.recentDeadlift = deadlift;
+        this.recentSquat = squat;
+    }
+
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
@@ -1,19 +1,41 @@
 package org.helloworld.gymmate.domain.user.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByOauth(Oauth oauth);
+    Optional<Member> findByOauth(Oauth oauth);
 
-	Optional<Member> findByMemberId(Long memberId);
+    Optional<Member> findByMemberId(Long memberId);
 
-	void deleteByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 
-	boolean existsByMemberId(Long memberId);
+    boolean existsByMemberId(Long memberId);
+
+    @Query(value = """
+        SELECT level
+        FROM gymmate_member
+        WHERE level IS NOT NULL
+        GROUP BY level
+        ORDER BY COUNT(*) DESC
+        LIMIT 1
+        """, nativeQuery = true)
+    int findMostLevel();
+
+    @Query("""
+        SELECT m
+        FROM Member m
+        WHERE m.recentBench IS NOT NULL
+        AND m.recentDeadlift IS NOT NULL
+        AND m.recentSquat IS NOT NULL
+        """)
+    List<Member> findAllWithRecentBigthree();
+
 }


### PR DESCRIPTION
# 📝 제목
feat(myself)
---

## 🔘 Part
- myself/bigthree

---

## 🔎 작업 내용
- bigthree 테이블에 등록, 수정, 삭제 발생 시 member테이블에 있는 recent_bench, recent_deadlift, recent_squat에 갱신되도록 로직을 추가했습니다.
- 등록한 3대를 갱신하는 로직은 `updateMemberRecentBigthree()` 으로 작성해두었습니다.  
- 같은 날 등록을 여러번 하는 경우를 대비해 (date DESC + bigthreeId DESC) 기준으로 최신 기록 판단합니다.

---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [ ] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 이전에 작업한 브랜치 (myself/feat/GYMMATE-231)에서 작업을 이어했더니 commit내역이 합쳐져 있습니다. 참고부탁드립니다.

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- GYMMATE-391

---
