### PR TITLE
refactor(myself): Bigthree Refactoring

### DIFF
--- a/src/main/java/org/helloworld/gymmate/common/exception/ErrorCode.java
+++ b/src/main/java/org/helloworld/gymmate/common/exception/ErrorCode.java
@@ -65,6 +65,7 @@ public enum ErrorCode {
     // Myself
     BIGTHREE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-BIGTHREE-001", "해당 3대 측정 기록을 찾을 수 없습니다."),
     DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-RECORD-001", "해당 운동 기록을 찾을 수 없습니다."),
+    BIGTHREE_AVERAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BIGTHREE-AVG-001", "3대 측정 평균 기록을 찾을 수 없습니다."),
 
     // 인증 관련
     AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증이 필요합니다. 로그인 후 다시 시도해주세요."),

--- a/src/main/java/org/helloworld/gymmate/common/exception/ErrorCode.java
+++ b/src/main/java/org/helloworld/gymmate/common/exception/ErrorCode.java
@@ -63,9 +63,10 @@ public enum ErrorCode {
     MACHINE_MAX_UPLOAD(HttpStatus.FORBIDDEN, "MACHINE-003", "기구정보는 최대 30개 등록 가능합니다."),
 
     // Myself
-    BIGTHREE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-BIGTHREE-001", "해당 3대 측정 기록을 찾을 수 없습니다."),
-    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-RECORD-001", "해당 운동 기록을 찾을 수 없습니다."),
-    BIGTHREE_AVERAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "BIGTHREE-AVG-001", "3대 측정 평균 기록을 찾을 수 없습니다."),
+    BIGTHREE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-001", "해당 3대 측정 기록을 찾을 수 없습니다."),
+    DIARY_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-002", "해당 운동 기록을 찾을 수 없습니다."),
+    BIGTHREE_ALREADY_EXISTS(HttpStatus.CONFLICT, "MYSELF-003", "해당 날짜에 3대 측정 기록이 이미 존재합니다."),
+    BIGTHREE_AVERAGE_NOT_FOUND(HttpStatus.NOT_FOUND, "MYSELF-004", "3대 측정 평균 기록을 찾을 수 없습니다."),
 
     // 인증 관련
     AUTH_REQUIRED(HttpStatus.UNAUTHORIZED, "AUTH-001", "인증이 필요합니다. 로그인 후 다시 시도해주세요."),

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/controller/BigthreeController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/controller/BigthreeController.java
@@ -42,27 +42,23 @@ public class BigthreeController {
 
         bigthreeService.deleteBigthree(bigthreeId, customOAuth2User.getUserId());
 
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.NO_CONTENT).build();
     }
 
     @PutMapping(value = "/{bigthreeId}")
-    public ResponseEntity<Void> modifyBigthree(
+    public ResponseEntity<Long> modifyBigthree(
         @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
         @PathVariable Long bigthreeId,
         @Valid @RequestBody BigthreeRequest request) {
 
-        bigthreeService.modifyBigthree(bigthreeId, request, customOAuth2User.getUserId());
-
-        return ResponseEntity.ok().build();
+        return ResponseEntity.status(HttpStatus.OK).body(
+            bigthreeService.modifyBigthree(bigthreeId, request, customOAuth2User.getUserId()));
     }
 
     @GetMapping(value = "/status")
     public ResponseEntity<BigthreeStatsResponse> getBigthreeStats(
         @AuthenticationPrincipal CustomOAuth2User customOAuth2User
     ) {
-        BigthreeStatsResponse response = bigthreeService.getBigthreeStats(customOAuth2User.getUserId());
-
-        return ResponseEntity.ok(response);
+        return ResponseEntity.ok(bigthreeService.getBigthreeStats(customOAuth2User.getUserId()));
     }
-
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/controller/BigthreeController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/controller/BigthreeController.java
@@ -1,15 +1,24 @@
 package org.helloworld.gymmate.domain.myself.bigthree.controller;
 
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeStatsResponse;
 import org.helloworld.gymmate.domain.myself.bigthree.service.BigthreeService;
 import org.helloworld.gymmate.security.oauth.entity.CustomOAuth2User;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
-import org.springframework.web.bind.annotation.*;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @RestController
 @RequestMapping("/bigthree")
@@ -19,16 +28,17 @@ public class BigthreeController {
 
     @PostMapping
     public ResponseEntity<Long> createBigthree(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @Valid @RequestBody BigthreeCreateRequest request) {
-        
-        return ResponseEntity.status(HttpStatus.CREATED).body(bigthreeService.createBigthree(request, customOAuth2User.getUserId()));
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @Valid @RequestBody BigthreeCreateRequest request) {
+
+        return ResponseEntity.status(HttpStatus.CREATED)
+            .body(bigthreeService.createBigthree(request, customOAuth2User.getUserId()));
     }
 
     @DeleteMapping(value = "/{bigthreeId}")
     public ResponseEntity<Void> deleteBigthree(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @PathVariable Long bigthreeId) {
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @PathVariable Long bigthreeId) {
 
         bigthreeService.deleteBigthree(bigthreeId, customOAuth2User.getUserId());
 
@@ -37,13 +47,22 @@ public class BigthreeController {
 
     @PutMapping(value = "/{bigthreeId}")
     public ResponseEntity<Void> modifyBigthree(
-            @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
-            @PathVariable Long bigthreeId,
-            @Valid @RequestBody BigthreeRequest request) {
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @PathVariable Long bigthreeId,
+        @Valid @RequestBody BigthreeRequest request) {
 
         bigthreeService.modifyBigthree(bigthreeId, request, customOAuth2User.getUserId());
 
         return ResponseEntity.ok().build();
+    }
+
+    @GetMapping(value = "/status")
+    public ResponseEntity<BigthreeStatsResponse> getBigthreeStats(
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User
+    ) {
+        BigthreeStatsResponse response = bigthreeService.getBigthreeStats(customOAuth2User.getUserId());
+
+        return ResponseEntity.ok(response);
     }
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeRequest.java
@@ -1,14 +1,11 @@
 package org.helloworld.gymmate.domain.myself.bigthree.dto;
 
-import jakarta.validation.constraints.Positive;
+import jakarta.validation.constraints.PositiveOrZero;
 
 public record BigthreeRequest(
-        @Positive(message = "벤치프레스 무게를 정확히 입력해주세요.")
-        double bench,
-        @Positive(message = "데드리프트 무게를 정확히 입력해주세요.")
-        double deadlift,
-        @Positive(message = "스쿼트 무게를 정확히 입력해주세요.")
-        double squat
+    @PositiveOrZero double bench,
+    @PositiveOrZero double deadlift,
+    @PositiveOrZero double squat
 ) {
 
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeStatsResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeStatsResponse.java
@@ -1,0 +1,19 @@
+package org.helloworld.gymmate.domain.myself.bigthree.dto;
+
+public record BigthreeStatsResponse(
+    int mostLevel,            // 가장 많은 일반 회원이 속한 레벨
+    double sumAverage,        // 전체 일반 회원의 3대 합산 평균
+    double benchAverage,      // 벤치프레스 평균
+    double deadliftAverage,   // 데드리프트 평균
+    double squatAverage,      // 스쿼트 평균
+
+    double recentBench,       // 내 최근 벤치 무게
+    double recentDeadlift,    // 내 최근 데드리프트 무게
+    double recentSquat,       // 내 최근 스쿼트 무게
+    double myAvg,            //(추가)사용자의 3대 평균
+
+    double benchRate,            //벤치 비율
+    double deadliftRate,         //데드리프트 비율
+    double squatRate            //스쿼트 비율
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeStatsResponse.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/dto/BigthreeStatsResponse.java
@@ -1,19 +1,22 @@
 package org.helloworld.gymmate.domain.myself.bigthree.dto;
 
+import jakarta.validation.constraints.PositiveOrZero;
+
 public record BigthreeStatsResponse(
-    int mostLevel,            // 가장 많은 일반 회원이 속한 레벨
-    double sumAverage,        // 전체 일반 회원의 3대 합산 평균
-    double benchAverage,      // 벤치프레스 평균
-    double deadliftAverage,   // 데드리프트 평균
-    double squatAverage,      // 스쿼트 평균
+    @PositiveOrZero int mostLevel,            // 가장 많은 일반 회원이 속한 레벨
 
-    double recentBench,       // 내 최근 벤치 무게
-    double recentDeadlift,    // 내 최근 데드리프트 무게
-    double recentSquat,       // 내 최근 스쿼트 무게
-    double myAvg,            //(추가)사용자의 3대 평균
+    @PositiveOrZero double sumAverage,        // 전체 일반 회원의 3대 합산 평균
+    @PositiveOrZero double benchAverage,      // 벤치프레스 평균
+    @PositiveOrZero double deadliftAverage,   // 데드리프트 평균
+    @PositiveOrZero double squatAverage,      // 스쿼트 평균
 
-    double benchRate,            //벤치 비율
-    double deadliftRate,         //데드리프트 비율
-    double squatRate            //스쿼트 비율
+    @PositiveOrZero double recentSum,            // 사용자의 3대 무게 합산
+    @PositiveOrZero double recentBench,       // 내 최근 벤치 무게
+    @PositiveOrZero double recentDeadlift,    // 내 최근 데드리프트 무게
+    @PositiveOrZero double recentSquat,       // 내 최근 스쿼트 무게
+
+    @PositiveOrZero double benchRate,            //벤치 비율
+    @PositiveOrZero double deadliftRate,         //데드리프트 비율
+    @PositiveOrZero double squatRate            //스쿼트 비율
 ) {
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/entity/Bigthree.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/entity/Bigthree.java
@@ -50,4 +50,10 @@ public class Bigthree {
 
     // ====== Business Logic ======
 
+    public void update(double bench, double deadlift, double squat) {
+        this.bench = bench;
+        this.deadlift = deadlift;
+        this.squat = squat;
+    }
+
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/mapper/BigthreeMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/mapper/BigthreeMapper.java
@@ -10,20 +10,28 @@ import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAvera
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.springframework.stereotype.Component;
 
+import io.micrometer.common.lang.Nullable;
+
 @Component
 public class BigthreeMapper {
     public static Bigthree toEntity(BigthreeCreateRequest request, Member member, LocalDate date) {
-        return toEntity(request.bigthreeRequest(), member, date);
+        return toEntity(request.bigthreeRequest(), member, date, null);
     }
 
-    public static Bigthree toEntity(BigthreeRequest request, Member member, LocalDate date) {
-        return Bigthree.builder()
+    public static Bigthree toEntity(BigthreeRequest request, Member member, LocalDate date,
+        @Nullable Long existingBigthreeId) {
+        Bigthree.BigthreeBuilder builder = Bigthree.builder()
             .bench(request.bench())
             .deadlift(request.deadlift())
             .squat(request.squat())
             .date(date)
-            .member(member)
-            .build();
+            .member(member);
+
+        if (existingBigthreeId != null) {
+            builder.bigthreeId(existingBigthreeId);
+        }
+
+        return builder.build();
     }
 
     public BigthreeStatsResponse toResponseDto(

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/mapper/BigthreeMapper.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/mapper/BigthreeMapper.java
@@ -1,12 +1,16 @@
 package org.helloworld.gymmate.domain.myself.bigthree.mapper;
 
-import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
-import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
-import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
-import org.helloworld.gymmate.domain.user.member.entity.Member;
-
 import java.time.LocalDate;
 
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeStatsResponse;
+import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.springframework.stereotype.Component;
+
+@Component
 public class BigthreeMapper {
     public static Bigthree toEntity(BigthreeCreateRequest request, Member member, LocalDate date) {
         return toEntity(request.bigthreeRequest(), member, date);
@@ -14,11 +18,38 @@ public class BigthreeMapper {
 
     public static Bigthree toEntity(BigthreeRequest request, Member member, LocalDate date) {
         return Bigthree.builder()
-                .bench(request.bench())
-                .deadlift(request.deadlift())
-                .squat(request.squat())
-                .date(date)
-                .member(member)
-                .build();
+            .bench(request.bench())
+            .deadlift(request.deadlift())
+            .squat(request.squat())
+            .date(date)
+            .member(member)
+            .build();
+    }
+
+    public BigthreeStatsResponse toResponseDto(
+        Member member,
+        BigthreeAverage average,
+        int mostLevel,
+        double benchRate,
+        double deadliftRate,
+        double squatRate,
+        double myAvg
+    ) {
+        return new BigthreeStatsResponse(
+            mostLevel,
+            average.getSumAverage(),
+            average.getBenchAverage(),
+            average.getDeadliftAverage(),
+            average.getSquatAverage(),
+
+            member.getRecentBench(),
+            member.getRecentDeadlift(),
+            member.getRecentSquat(),
+            myAvg,
+
+            benchRate,
+            deadliftRate,
+            squatRate
+        );
     }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/repository/BigthreeRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/repository/BigthreeRepository.java
@@ -1,5 +1,6 @@
 package org.helloworld.gymmate.domain.myself.bigthree.repository;
 
+import java.time.LocalDate;
 import java.util.Optional;
 
 import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
@@ -10,6 +11,9 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface BigthreeRepository extends JpaRepository<Bigthree, Long> {
 
-    // 3대 등록을 같은 날 여러번 한 경우, 더 나중에 등록된 기록을 우선
-    Optional<Bigthree> findTopByMemberOrderByDateDescBigthreeIdDesc(Member member);
+    // 해당 날짜 기록 가져오기
+    Optional<Bigthree> findByMemberAndDate(Member member, LocalDate date);
+
+    // 최신 날짜 기록 가져오기
+    Optional<Bigthree> findTopByMemberOrderByDateDesc(Member member);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/repository/BigthreeRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/repository/BigthreeRepository.java
@@ -1,9 +1,15 @@
 package org.helloworld.gymmate.domain.myself.bigthree.repository;
 
+import java.util.Optional;
+
 import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface BigthreeRepository extends JpaRepository<Bigthree, Long> {
+
+    // 3대 등록을 같은 날 여러번 한 경우, 더 나중에 등록된 기록을 우선
+    Optional<Bigthree> findTopByMemberOrderByDateDescBigthreeIdDesc(Member member);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
@@ -112,8 +112,8 @@ public class BigthreeService {
             });
     }
 
+    /**기존 3대 측정 기록 가져오기 */
     private Bigthree getExistingBigthree(Long bigthreeId) {
-        //기존 3대 측정 기록 가져오기
         return bigthreeRepository.findById(bigthreeId)
             .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND));
     }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
@@ -1,26 +1,34 @@
 package org.helloworld.gymmate.domain.myself.bigthree.service;
 
-import jakarta.transaction.Transactional;
-import jakarta.validation.Valid;
-import lombok.RequiredArgsConstructor;
+import java.time.LocalDate;
+
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeCreateRequest;
 import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeRequest;
+import org.helloworld.gymmate.domain.myself.bigthree.dto.BigthreeStatsResponse;
 import org.helloworld.gymmate.domain.myself.bigthree.entity.Bigthree;
 import org.helloworld.gymmate.domain.myself.bigthree.mapper.BigthreeMapper;
 import org.helloworld.gymmate.domain.myself.bigthree.repository.BigthreeRepository;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.repository.BigthreeAverageRepository;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.helloworld.gymmate.domain.user.member.repository.MemberRepository;
 import org.helloworld.gymmate.domain.user.member.service.MemberService;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
-import java.time.LocalDate;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
 
 @Service
 @RequiredArgsConstructor
 public class BigthreeService {
     private final BigthreeRepository bigthreeRepository;
     private final MemberService memberService;
+    private final BigthreeAverageRepository bigthreeAverageRepository;
+    private final BigthreeMapper bigthreeMapper;
+    private final MemberRepository memberRepository;
 
     @Transactional
     public long createBigthree(@Valid BigthreeCreateRequest request, Long memberId) {
@@ -62,7 +70,7 @@ public class BigthreeService {
     private Bigthree getExistingBigthree(Long bigthreeId) {
         //기존 3대 측정 기록 가져오기
         return bigthreeRepository.findById(bigthreeId)
-                .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND));
+            .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND));
     }
 
     private void validateBigthreeOwner(Bigthree bigthree, Member member) {
@@ -72,4 +80,49 @@ public class BigthreeService {
         }
     }
 
+    //TODO: Bigthree 테이블에 저장된 기록 중 가장 최신값 회원의  recent필드에 업데이트하는 로직
+
+    // 3대 측정 통계
+    @Transactional(readOnly = true)
+    public BigthreeStatsResponse getBigthreeStats(Long memberId) {
+        Member member = getMember(memberId);
+
+        if (member.getRecentBench() == null || member.getRecentDeadlift() == null || member.getRecentSquat() == null) {
+            throw new BusinessException(ErrorCode.BIGTHREE_NOT_FOUND);
+        }
+
+        BigthreeAverage average = getLatestBigthreeAverage();
+        int mostLevel = getMostLevel();
+        double myTotal = member.getRecentBench() + member.getRecentDeadlift() + member.getRecentSquat();
+
+        double benchRate = calculateRate(member.getRecentBench(), myTotal);
+        double deadliftRate = calculateRate(member.getRecentDeadlift(), myTotal);
+        double squatRate = calculateRate(member.getRecentSquat(), myTotal);
+
+        double myAvg = myTotal / 3.0;
+
+        return bigthreeMapper.toResponseDto(member, average, mostLevel, benchRate, deadliftRate, squatRate, myAvg);
+    }
+
+    private double calculateRate(Double myWeight, Double myTotal) {
+        if (myTotal == null || myTotal == 0.0)
+            return 0;
+
+        // 비율 계산 후 소수점 둘째자리까지 반올림
+        double rawRate = (myWeight / myTotal) * 100;
+        return Math.round(rawRate * 100.0) / 100.0;
+    }
+
+    private BigthreeAverage getLatestBigthreeAverage() {
+        // 3대 측정 평균 가져오기
+        return bigthreeAverageRepository.findTopByOrderByBigthreeAverageIdDesc()
+            .orElseThrow(() -> new BusinessException(ErrorCode.BIGTHREE_AVERAGE_NOT_FOUND));
+    }
+
+    private int getMostLevel() {
+        // 많은 일반 회원이 속한 레벨 가져오기
+        return memberRepository.findMostLevel();
+    }
+
 }
+

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/entity/BigthreeAverage.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/entity/BigthreeAverage.java
@@ -1,0 +1,39 @@
+package org.helloworld.gymmate.domain.myself.bigthreeaverage.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Builder
+@Table(name = "bigthree_average")
+public class BigthreeAverage {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "bigthree_average_id")
+    private Long bigthreeAverageId;
+
+    @Column(name = "sum_average", nullable = false)
+    private double sumAverage;
+
+    @Column(name = "bench_average", nullable = false)
+    private double benchAverage;
+
+    @Column(name = "deadlift_average", nullable = false)
+    private double deadliftAverage;
+
+    @Column(name = "squat_average", nullable = false)
+    private double squatAverage;
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/entity/BigthreeAverage.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/entity/BigthreeAverage.java
@@ -2,8 +2,6 @@ package org.helloworld.gymmate.domain.myself.bigthreeaverage.entity;
 
 import jakarta.persistence.Column;
 import jakarta.persistence.Entity;
-import jakarta.persistence.GeneratedValue;
-import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
 import lombok.AccessLevel;
@@ -19,11 +17,9 @@ import lombok.NoArgsConstructor;
 @Builder
 @Table(name = "bigthree_average")
 public class BigthreeAverage {
-
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
     @Column(name = "bigthree_average_id")
-    private Long bigthreeAverageId;
+    private Long bigthreeAverageId; // 1로 고정
 
     @Column(name = "sum_average", nullable = false)
     private double sumAverage;

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/repository/BigthreeAverageRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/repository/BigthreeAverageRepository.java
@@ -1,0 +1,10 @@
+package org.helloworld.gymmate.domain.myself.bigthreeaverage.repository;
+
+import java.util.Optional;
+
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface BigthreeAverageRepository extends JpaRepository<BigthreeAverage, Long> {
+    Optional<BigthreeAverage> findTopByOrderByBigthreeAverageIdDesc();
+}

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/repository/BigthreeAverageRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/repository/BigthreeAverageRepository.java
@@ -6,5 +6,6 @@ import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAvera
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface BigthreeAverageRepository extends JpaRepository<BigthreeAverage, Long> {
-    Optional<BigthreeAverage> findTopByOrderByBigthreeAverageIdDesc();
+    // 항상 id = 1로 요청해야 함
+    Optional<BigthreeAverage> findByBigthreeAverageId(Long id);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/scheduler/BigthreeAverageScheduler.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthreeaverage/scheduler/BigthreeAverageScheduler.java
@@ -1,0 +1,71 @@
+package org.helloworld.gymmate.domain.myself.bigthreeaverage.scheduler;
+
+import java.util.List;
+
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.entity.BigthreeAverage;
+import org.helloworld.gymmate.domain.myself.bigthreeaverage.repository.BigthreeAverageRepository;
+import org.helloworld.gymmate.domain.user.member.entity.Member;
+import org.helloworld.gymmate.domain.user.member.repository.MemberRepository;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class BigthreeAverageScheduler {
+
+    private final MemberRepository memberRepository;
+    private final BigthreeAverageRepository bigthreeAverageRepository;
+
+    @Scheduled(cron = "0 0 0  * * *") //매일 자정 실행
+    @Transactional
+    public void updateBigthreeAverage() {
+        // 최근 벤치, 데드리프트, 스쿼트 값이 모두 있는 일반 회원 조회
+        List<Member> members = memberRepository.findAllWithRecentBigthree();
+
+        if (members.isEmpty()) {
+            log.debug("3대 평균 계산을 위한 일반 회원 데이터가 없습니다.");
+            return;
+        }
+
+        double totalBench = 0, totalDeadlift = 0, totalSquat = 0, totalSum = 0;
+        for (Member m : members) {
+            double bench = m.getRecentBench();
+            double deadlift = m.getRecentDeadlift();
+            double squat = m.getRecentSquat();
+
+            totalBench += bench;
+            totalDeadlift += deadlift;
+            totalSquat += squat;
+
+            totalSum += bench + deadlift + squat;
+        }
+
+        int count = members.size();
+        double benchAvg = roundTo2(totalBench / count);
+        double deadliftAvg = roundTo2(totalDeadlift / count);
+        double squatAvg = roundTo2(totalSquat / count);
+        double sumAvg = roundTo2(totalSum / count);
+
+        BigthreeAverage average = BigthreeAverage.builder()
+            .benchAverage(benchAvg)
+            .deadliftAverage(deadliftAvg)
+            .squatAverage(squatAvg)
+            .sumAverage(sumAvg)
+            .build();
+
+        bigthreeAverageRepository.save(average);
+        log.debug("3대 평균 저장 완료 : bench={}, deadlift={}, squat={}, sum={}",
+            benchAvg, deadliftAvg, squatAvg, sumAvg);
+    }
+
+    // 소수점 둘째 자리까지 반올림해서 DB에 저장
+    private double roundTo2(double value) {
+        return Math.round(value * 100.0) / 100.0;
+    }
+
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/entity/Member.java
@@ -35,113 +35,120 @@ import lombok.NoArgsConstructor;
 @Table(name = "gymmate_member")
 public class Member {
 
-	@Id
-	@GeneratedValue(strategy = GenerationType.IDENTITY)
-	@Column(name = "member_id")
-	private Long memberId;
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "member_id")
+    private Long memberId;
 
-	@Column(name = "phone_number", unique = true)
-	private String phoneNumber;
+    @Column(name = "phone_number", unique = true)
+    private String phoneNumber;
 
-	@Column(name = "member_name")
-	private String memberName;
+    @Column(name = "member_name")
+    private String memberName;
 
-	@Column(name = "email")
-	private String email;
+    @Column(name = "email")
+    private String email;
 
-	@Column(name = "birthday")
-	private String birthday;
+    @Column(name = "birthday")
+    private String birthday;
 
-	@Convert(converter = GenderTypeConverter.class)
-	@Column(name = "gender_type")
-	private GenderType genderType;
+    @Convert(converter = GenderTypeConverter.class)
+    @Column(name = "gender_type")
+    private GenderType genderType;
 
-	@Column(name = "height")
-	private String height; //신체정보
+    @Column(name = "height")
+    private String height; //신체정보
 
-	@Column(name = "weight")
-	private String weight;
+    @Column(name = "weight")
+    private String weight;
 
-	@Column(name = "address")
-	private String address; //주소
+    @Column(name = "address")
+    private String address; //주소
 
-	@Column(name = "x_field")
-	private Double xField;
+    @Column(name = "x_field")
+    private Double xField;
 
-	@Column(name = "y_field")
-	private Double yField;
+    @Column(name = "y_field")
+    private Double yField;
 
-	@Column(name = "recent_bench")
-	private Double recentBench; //3대 - 밴치프레스
+    @Column(name = "recent_bench")
+    private Double recentBench; //3대 - 밴치프레스
 
-	@Column(name = "recent_deadlift")
-	private Double recentDeadlift; //3대 - 데드리프트
+    @Column(name = "recent_deadlift")
+    private Double recentDeadlift; //3대 - 데드리프트
 
-	@Column(name = "recent_squat")
-	private Double recentSquat; //3대 - 스쿼트
+    @Column(name = "recent_squat")
+    private Double recentSquat; //3대 - 스쿼트
 
-	@Column(name = "level")
-	private Integer level; //3대 - 레벨
+    @Column(name = "level")
+    private Integer level; //3대 - 레벨
 
-	@Column(name = "profile_url")
-	private String profileUrl;
+    @Column(name = "profile_url")
+    private String profileUrl;
 
-	@Column(name = "is_account_nonlocked")
-	private Boolean isAccountNonLocked; //계정잠김여부
+    @Column(name = "is_account_nonlocked")
+    private Boolean isAccountNonLocked; //계정잠김여부
 
-	@Column(name = "additional_info_completed")
-	private Boolean additionalInfoCompleted; // 추가 정보 입력 여부
+    @Column(name = "additional_info_completed")
+    private Boolean additionalInfoCompleted; // 추가 정보 입력 여부
 
-	@Column(name = "cash")
-	private Long cash;
+    @Column(name = "cash")
+    private Long cash;
 
-	@OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
-	@JoinColumn(name = "oauth_id")
-	private Oauth oauth;
+    @OneToOne(cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @JoinColumn(name = "oauth_id")
+    private Oauth oauth;
 
-	@OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
-	@Builder.Default
-	private List<GymTicket> gymTickets = new ArrayList<>();
+    @OneToMany(mappedBy = "member", cascade = CascadeType.ALL, orphanRemoval = true)
+    @Builder.Default
+    private List<GymTicket> gymTickets = new ArrayList<>();
 
-	// ====== Business Logic ======
+    // ====== Business Logic ======
 
-	public void registerMemberInfo(MemberRequest request) {
-		this.phoneNumber = request.phoneNumber();
-		this.memberName = request.memberName();
-		this.email = request.email();
-		this.birthday = request.birthday();
-		this.genderType = GenderType.fromString(request.gender());
-		this.height = request.height();
-		this.weight = request.weight();
-		this.address = request.address();
-		this.xField = request.xField();
-		this.yField = request.yField();
-		this.recentBench = request.recentBench();
-		this.recentDeadlift = request.recentDeadlift();
-		this.recentSquat = request.recentSquat();
-		this.additionalInfoCompleted = true;
+    public void registerMemberInfo(MemberRequest request) {
+        this.phoneNumber = request.phoneNumber();
+        this.memberName = request.memberName();
+        this.email = request.email();
+        this.birthday = request.birthday();
+        this.genderType = GenderType.fromString(request.gender());
+        this.height = request.height();
+        this.weight = request.weight();
+        this.address = request.address();
+        this.xField = request.xField();
+        this.yField = request.yField();
+        this.recentBench = request.recentBench();
+        this.recentDeadlift = request.recentDeadlift();
+        this.recentSquat = request.recentSquat();
+        this.additionalInfoCompleted = true;
 
-	}
+    }
 
-	public void modifyMemberInfo(MemberRequest request, String profileUrl) {
-		this.phoneNumber = request.phoneNumber();
-		this.memberName = request.memberName();
-		this.email = request.email();
-		this.birthday = request.birthday();
-		this.genderType = GenderType.fromString(request.gender());
-		this.height = request.height();
-		this.weight = request.weight();
-		this.address = request.address();
-		this.xField = request.xField();
-		this.yField = request.yField();
-		this.recentBench = request.recentBench();
-		this.recentDeadlift = request.recentDeadlift();
-		this.recentSquat = request.recentSquat();
-		this.profileUrl = profileUrl;
-		this.additionalInfoCompleted = true;
-	}
+    public void modifyMemberInfo(MemberRequest request, String profileUrl) {
+        this.phoneNumber = request.phoneNumber();
+        this.memberName = request.memberName();
+        this.email = request.email();
+        this.birthday = request.birthday();
+        this.genderType = GenderType.fromString(request.gender());
+        this.height = request.height();
+        this.weight = request.weight();
+        this.address = request.address();
+        this.xField = request.xField();
+        this.yField = request.yField();
+        this.recentBench = request.recentBench();
+        this.recentDeadlift = request.recentDeadlift();
+        this.recentSquat = request.recentSquat();
+        this.profileUrl = profileUrl;
+        this.additionalInfoCompleted = true;
+    }
 
-	public void updateCash(Long updateCash) {
-		this.cash = updateCash;
-	}
+    public void updateCash(Long updateCash) {
+        this.cash = updateCash;
+    }
+
+    public void updateRecentBigthree(double bench, double deadlift, double squat) {
+        this.recentBench = bench;
+        this.recentDeadlift = deadlift;
+        this.recentSquat = squat;
+    }
+
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
@@ -1,19 +1,41 @@
 package org.helloworld.gymmate.domain.user.member.repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.stereotype.Repository;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member, Long> {
-	Optional<Member> findByOauth(Oauth oauth);
+    Optional<Member> findByOauth(Oauth oauth);
 
-	Optional<Member> findByMemberId(Long memberId);
+    Optional<Member> findByMemberId(Long memberId);
 
-	void deleteByMemberId(Long memberId);
+    void deleteByMemberId(Long memberId);
 
-	boolean existsByMemberId(Long memberId);
+    boolean existsByMemberId(Long memberId);
+
+    @Query(value = """
+        SELECT level
+        FROM gymmate_member
+        WHERE level IS NOT NULL
+        GROUP BY level
+        ORDER BY COUNT(*) DESC
+        LIMIT 1
+        """, nativeQuery = true)
+    int findMostLevel();
+
+    @Query("""
+        SELECT m
+        FROM Member m
+        WHERE m.recentBench IS NOT NULL
+        AND m.recentDeadlift IS NOT NULL
+        AND m.recentSquat IS NOT NULL
+        """)
+    List<Member> findAllWithRecentBigthree();
+
 }

--- a/src/main/resources/db/migration/V2__rename_bigthree_average_id.sql
+++ b/src/main/resources/db/migration/V2__rename_bigthree_average_id.sql
@@ -1,0 +1,1 @@
+ALTER TABLE bigthree_average RENAME COLUMN bigthree_id TO bigthree_average_id;

--- a/src/main/resources/db/migration/V3__add_unique_constraints_to_diary_and_bigthree.sql
+++ b/src/main/resources/db/migration/V3__add_unique_constraints_to_diary_and_bigthree.sql
@@ -1,0 +1,7 @@
+-- 1. diary 테이블에 member_id와 date 조합 유니크 제약 추가
+ALTER TABLE diary
+    ADD CONSTRAINT uq_member_date UNIQUE (member_id, `date`);
+
+-- 2. bigthree 테이블에 member_id와 date 조합 유니크 제약 추가
+ALTER TABLE bigthree
+    ADD CONSTRAINT uq_bigthree_date UNIQUE (member_id, `date`);

--- a/src/main/resources/db/migration/V4__fix_bigthree_average_id.sql
+++ b/src/main/resources/db/migration/V4__fix_bigthree_average_id.sql
@@ -1,0 +1,7 @@
+-- 1. 기존 AUTO_INCREMENT 제거
+ALTER TABLE bigthree_average
+    MODIFY bigthree_average_id BIGINT NOT NULL;
+
+-- 2. ID가 항상 1인지 확인하는 CHECK 제약 추가
+ALTER TABLE bigthree_average
+    ADD CONSTRAINT chk_bigthree_average_id CHECK (bigthree_average_id = 1);


### PR DESCRIPTION
# 📝 Bigthree 리팩토링

---

## 🔘 Part
- myself

---

## 🔎 작업 내용
- #149 병합
- #155 병합
- 잘못된 bigthree_average 테이블 필드명 수정
  bigthree_id -> bigthree_average_id
- 유니크 제약 조건 추가
  diary 및 bigthree 테이블은 멤버 당 하루에 1개의 데이터만 존재 가능
- bigthree_average 테이블 단일 튜플 제약 추가
 항상 id가 1인 1개의 데이터만 존재 가능
- 변경된 테이블에 따라 repository 메소드 수정
- modify 기존 로직 복구 및 개선 후 테스트 통과

---

## 🖼️ 이미지 첨부

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료 (추가, 수정, 삭제 포스트맨 테스트 수행 완료)

---

## 🙏 리뷰 요청 사항

### 새로운 주석 형식 도입
메소드 위에 주석을 다음과 같은 형식으로 작성했을 때,
메소드 호출하는 곳에서 해당 메소드에 마우스를 올려두면
주석 내용이 보입니다

```
/**기존 3대 측정 기록 가져오기 */
```

---

## 🔧 앞으로의 과제
- 통계 수정 후 병합 예정
- 기록 조회 추가 시 같이 병합할 수도 있음

---

## ➕ 이슈 링크
- 

---
