### PR TITLE
fix(myself): Improve Bigthree Scheduler & Bigthree Data Correction

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/myself/bigthree/service/BigthreeService.java
@@ -1,6 +1,7 @@
 package org.helloworld.gymmate.domain.myself.bigthree.service;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 import org.helloworld.gymmate.common.exception.BusinessException;
 import org.helloworld.gymmate.common.exception.ErrorCode;
@@ -167,7 +168,7 @@ public class BigthreeService {
 
     /** 많은 일반 회원이 속한 레벨 가져오기 */
     private int getMostLevel() {
-        return memberRepository.findMostLevel();
+        return Optional.ofNullable(memberRepository.findMostLevel()).orElse(0);
     }
 }
 

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/repository/MemberRepository.java
@@ -16,7 +16,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
     Optional<Member> findByMemberId(Long memberId);
 
     void deleteByMemberId(Long memberId);
-    
+
     @Query(value = """
         SELECT level
         FROM gymmate_member
@@ -25,7 +25,7 @@ public interface MemberRepository extends JpaRepository<Member, Long> {
         ORDER BY COUNT(*) DESC
         LIMIT 1
         """, nativeQuery = true)
-    int findMostLevel();
+    Integer findMostLevel();
 
     @Query("""
         SELECT m

--- a/src/main/resources/db/migration/V5__insert_missing_bigthree.sql
+++ b/src/main/resources/db/migration/V5__insert_missing_bigthree.sql
@@ -1,0 +1,13 @@
+-- gymmate_member 테이블의 모든 회원 중에서,
+-- 해당 회원의 member_id로 bigthree 레코드가 하나도 존재하지 않는 경우
+-- 오늘 날짜로 bigthree 생성
+INSERT INTO bigthree (bench, deadlift, squat, `date`, member_id)
+SELECT m.recent_bench,
+       m.recent_deadlift,
+       m.recent_squat,
+       CURRENT_DATE,
+       m.member_id
+FROM gymmate_member m
+WHERE NOT EXISTS (SELECT 1
+                  FROM bigthree b
+                  WHERE b.member_id = m.member_id);

--- a/src/main/resources/db/migration/V6__reset_null_lifts_and_bigthree.sql
+++ b/src/main/resources/db/migration/V6__reset_null_lifts_and_bigthree.sql
@@ -1,0 +1,33 @@
+-- 1. 대상 member_id를 임시 테이블에 저장 - recent 3대 무게 필드 중 하나라도 NULL인 경우
+CREATE TEMPORARY TABLE temp_reset_members AS
+SELECT member_id
+FROM gymmate_member
+WHERE recent_bench IS NULL
+   OR recent_deadlift IS NULL
+   OR recent_squat IS NULL;
+
+-- 2. 임시 테이블 대상 중 NULL인 recent 무게 필드만 0으로 업데이트
+UPDATE gymmate_member
+SET recent_bench    = COALESCE(recent_bench, 0),
+    recent_deadlift = COALESCE(recent_deadlift, 0),
+    recent_squat    = COALESCE(recent_squat, 0)
+WHERE member_id IN (SELECT member_id FROM temp_reset_members);
+
+-- 3. 모든 회원의 level 재계산 (recent 값 기준 합산으로 계산)
+UPDATE gymmate_member
+SET `level` = CASE
+                  WHEN (recent_bench + recent_deadlift + recent_squat) < 100 THEN 0
+                  WHEN (recent_bench + recent_deadlift + recent_squat) < 200 THEN 1
+                  WHEN (recent_bench + recent_deadlift + recent_squat) < 300 THEN 2
+                  WHEN (recent_bench + recent_deadlift + recent_squat) < 400 THEN 3
+                  ELSE 4
+    END;
+
+-- 4. 임시 테이블 대상 중 recent 값 기준으로 오늘 날짜의 bigthree 기록 데이터 삽입
+INSERT INTO bigthree (bench, deadlift, squat, `date`, member_id)
+SELECT recent_bench, recent_deadlift, recent_squat, CURRENT_DATE, member_id
+FROM gymmate_member
+WHERE member_id IN (SELECT member_id FROM temp_reset_members);
+
+-- 5. 임시 테이블 삭제
+DROP TEMPORARY TABLE temp_reset_members;


### PR DESCRIPTION
# 📝 3대 기록 스케쥴러 개선 & 3대 기록 데이터 오류 수정

---

## 🔘 Part
- bigthree 

---

## 🔎 작업 내용
- 3대 기록 스케쥴러 개선
  프로그램 부팅 시 3대 기록 전체 회원 평균값이 없으면 스케쥴러 실행
- (service) 3대 통계 조회 예외 상황 처리
  평균 테이블에 레벨이 없을 경우 0으로 반환
- flyway로 기존 3대 기록 db 데이터 오류 수정
  3대 기록이 없는 회원 오늘 날짜로 기록 추가
  3대 무게 및 레벨 정보에 오류가 있는 회원 데이터 수정

---

## 🖼️ 이미지 첨부

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료 (스케쥴러 수행 O, flyway 수행 O, 조회 postman O)

---

## 🙏 리뷰 요청 사항
- 저번에 수정 후 재테스트를 안했어서 (죄송합니다!ㅠㅜㅠ)
  이번에는 다 테스트 해봤습니다 혹시 오류나면 또 말씀해주세요
- 오늘 자정 전에 병합해서 pull 하지 않으면 오류가 발생할 수 있습니다

---

## 🔧 앞으로의 과제
- 

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
