### PR TITLE
feat(trainerreview) : 트레이너 리뷰 삭제 

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/pt/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/reservation/repository/ReservationRepository.java
@@ -30,7 +30,16 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
         """, nativeQuery = true)
     Optional<Reservation> find(@Param("memberId") Long memberId, @Param("trainerId") Long trainerId);
 
-    boolean existsByMemberIdAndCancelDateIsNullAndCompletedDateIsNull(Long memberId);
+    @Query(value = """
+        SELECT IF(
+          EXISTS(
+            SELECT 1 FROM reservation r
+            WHERE r.member_id = :memberId
+              AND r.cancel_date IS NULL
+              AND DATE_ADD(r.date, INTERVAL r.time HOUR) > CURRENT_TIMESTAMP
+          ), 1, 0)
+        """, nativeQuery = true)
+    Long existsReservation(@Param("memberId") Long memberId);
 
     @Modifying
     @Query("UPDATE Reservation r SET r.memberId = null WHERE r.memberId = :memberId")

--- a/src/main/java/org/helloworld/gymmate/domain/pt/reservation/repository/ReservationRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/pt/reservation/repository/ReservationRepository.java
@@ -35,4 +35,6 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     @Modifying
     @Query("UPDATE Reservation r SET r.memberId = null WHERE r.memberId = :memberId")
     void setMemberIdNullByMemberId(@Param("memberId") Long memberId);
+
+    void deleteAllByTrainerId(Long trainerId);
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
@@ -1,5 +1,6 @@
 package org.helloworld.gymmate.domain.user.member.service;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.helloworld.gymmate.common.exception.BusinessException;
@@ -20,9 +21,14 @@ import org.helloworld.gymmate.domain.user.member.dto.MemberResponse;
 import org.helloworld.gymmate.domain.user.member.entity.Member;
 import org.helloworld.gymmate.domain.user.member.mapper.MemberMapper;
 import org.helloworld.gymmate.domain.user.member.repository.MemberRepository;
+import org.helloworld.gymmate.domain.user.trainer.trainerreview.entity.TrainerReview;
+import org.helloworld.gymmate.domain.user.trainer.trainerreview.entity.TrainerReviewImage;
+import org.helloworld.gymmate.domain.user.trainer.trainerreview.event.TrainerReviewDeleteEvent;
+import org.helloworld.gymmate.domain.user.trainer.trainerreview.repository.TrainerReviewRepository;
 import org.helloworld.gymmate.infra.service.KakaoMapRestTemplateComponent;
 import org.helloworld.gymmate.security.oauth.entity.Oauth;
 import org.helloworld.gymmate.security.oauth.repository.OauthRepository;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.multipart.MultipartFile;
@@ -47,6 +53,8 @@ public class MemberService {
     private final StudentRepository studentRepository;
     private final ReservationRepository reservationRepository;
     private final GymTicketRepository gymTicketRepository;
+    private final TrainerReviewRepository trainerReviewRepository;
+    private final ApplicationEventPublisher eventPublisher;
 
     /** 빈 member 객체 생성 */
     @Transactional
@@ -162,7 +170,6 @@ public class MemberService {
     }
 
     private void deleteRelatedEntitiesOfMember(Long memberId) {
-        // TODO: trainerReview 삭제 , 캐시로그도 삭제?
         // 설명 : 연관관계가 설정된 경우에는 Member_MemberId, 컬럼으로만 추가한 경우에는 MemberId
         diaryRepository.deleteAllByMember_MemberId(memberId);
         bigthreeRepository.deleteAllByMember_MemberId(memberId);
@@ -170,5 +177,15 @@ public class MemberService {
         studentRepository.deleteAllByMemberId(memberId);
         reservationRepository.setMemberIdNullByMemberId(memberId); // 예약내역은 삭제 대신 memberId = null
         gymTicketRepository.deleteAllByMember_MemberId(memberId);
+        List<TrainerReview> reviews = trainerReviewRepository.findAllByMemberId(memberId);
+        if (!reviews.isEmpty()) {
+            List<TrainerReviewImage> imagesToDelete = reviews.stream()
+                .flatMap(review -> review.getImages().stream())
+                .toList();
+            if (!imagesToDelete.isEmpty()) {
+                eventPublisher.publishEvent(new TrainerReviewDeleteEvent(imagesToDelete));
+            }
+            trainerReviewRepository.deleteAll(reviews);
+        }
     }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/member/service/MemberService.java
@@ -160,7 +160,7 @@ public class MemberService {
 
     private void validateDeletable(Long memberId) {
         // 유효한 PT예약이 있을 경우
-        if (reservationRepository.existsByMemberIdAndCancelDateIsNullAndCompletedDateIsNull(memberId)) {
+        if (reservationRepository.existsReservation(memberId) == 1) {
             throw new BusinessException(ErrorCode.CANNOT_DELETE_MEMBER_VALID_RESERVATION);
         }
         // 유효한 헬스장 이용권이 있을 경우

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/controller/TrainerReviewController.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/controller/TrainerReviewController.java
@@ -12,6 +12,7 @@ import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.access.prepost.PreAuthorize;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -57,5 +58,16 @@ public class TrainerReviewController {
         return ResponseEntity.ok()
             .body(trainerReviewService.modifyTrainerReview(request, images, trainerReviewId,
                 customOAuth2User.getUserId()));
+    }
+
+    @Operation(summary = "[일반 회원] 트레이너 리뷰 삭제")
+    @PreAuthorize("hasRole('ROLE_MEMBER')")
+    @DeleteMapping("/{trainerReviewId}")
+    public ResponseEntity<Void> deleteTrainerReview(
+        @AuthenticationPrincipal CustomOAuth2User customOAuth2User,
+        @PathVariable Long trainerReviewId
+    ) {
+        trainerReviewService.deleteTrainerReview(trainerReviewId, customOAuth2User.getUserId());
+        return ResponseEntity.ok().build();
     }
 }

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/dto/request/TrainerReviewCreateRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/dto/request/TrainerReviewCreateRequest.java
@@ -1,9 +1,10 @@
 package org.helloworld.gymmate.domain.user.trainer.trainerreview.dto.request;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record TrainerReviewCreateRequest(
-    @Min(0) double score,
+    @Min(0) @Max(5) double score,
     String content,
     @Min(1) Long trainerId
 ) {

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/dto/request/TrainerReviewModifyRequest.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/dto/request/TrainerReviewModifyRequest.java
@@ -2,10 +2,11 @@ package org.helloworld.gymmate.domain.user.trainer.trainerreview.dto.request;
 
 import java.util.List;
 
+import jakarta.validation.constraints.Max;
 import jakarta.validation.constraints.Min;
 
 public record TrainerReviewModifyRequest(
-    @Min(0) double score,
+    @Min(0) @Max(5) double score,
     String content,
     List<String> deleteImageUrls
 ) {

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/event/TrainerReviewDeleteEvent.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/event/TrainerReviewDeleteEvent.java
@@ -1,0 +1,10 @@
+package org.helloworld.gymmate.domain.user.trainer.trainerreview.event;
+
+import java.util.List;
+
+import org.helloworld.gymmate.domain.user.trainer.trainerreview.entity.TrainerReviewImage;
+
+public record TrainerReviewDeleteEvent(
+    List<TrainerReviewImage> images
+) {
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/event/TrainerReviewDeleteEventListener.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/event/TrainerReviewDeleteEventListener.java
@@ -1,0 +1,27 @@
+package org.helloworld.gymmate.domain.user.trainer.trainerreview.event;
+
+import org.helloworld.gymmate.common.s3.FileManager;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.event.TransactionPhase;
+import org.springframework.transaction.event.TransactionalEventListener;
+
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class TrainerReviewDeleteEventListener {
+    private final FileManager fileManager;
+
+    @TransactionalEventListener(phase = TransactionPhase.AFTER_COMMIT)
+    public void handleTrainerReviewDeletion(TrainerReviewDeleteEvent event) {
+        event.images().forEach(image -> {
+            try {
+                fileManager.deleteFile(image.getUrl());
+            } catch (Exception ex) {
+                log.error("image Url : {} , error : {} ", image.getUrl(), ex.getMessage());
+            }
+        });
+    }
+}

--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/repository/TrainerReviewRepository.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/trainerreview/repository/TrainerReviewRepository.java
@@ -1,7 +1,12 @@
 package org.helloworld.gymmate.domain.user.trainer.trainerreview.repository;
 
+import java.util.List;
+
 import org.helloworld.gymmate.domain.user.trainer.trainerreview.entity.TrainerReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface TrainerReviewRepository extends JpaRepository<TrainerReview, Long> {
+    List<TrainerReview> findAllByTrainer_TrainerId(Long trainerId);
+
+    List<TrainerReview> findAllByMemberId(Long memberId);
 }


### PR DESCRIPTION
# 📝 제목
feat(도메인): 내용 요약

---

## 🔘 Part
- 도메인

---

## 🔎 작업 내용
- S3에서 파일을 삭제하는 것도 같은 트랜잭션 내에 이뤄지게 코드를 작성했었는데 이렇게 되면 DB에서 삭제하는건 성공하고 S3에서 삭제는 실패할 경우 롤백이 되기때문에 별도의 트랜잭션에서 이루어지는게 맞는것 같아서 evnet를 적용해 처리하였습니다
- 유효한 예약을 찾을때 현재 시간보다 예약한 시간이 현재 시간보다 이후여야 하므로 그에 맞게 코드를 수정하였습니다

---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 리뷰 삭제, 트레이너 탈퇴시 리뷰 삭제 까지 확인하였는데 멤버 회원탈퇴는 아직 테스트 해보지 못했습니다. 문제 있으시면 알려주세요!
- 멤버 회원 탈퇴토 테스트 완료했습니다!
---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등
트레이너 리뷰 조회
---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
