### PR TITLE
refactor(dummy): 헬스장주인(트레이너)의 gym_id추가

### DIFF
--- a/src/main/java/org/helloworld/gymmate/dummy/controller/DummyDataController.java
+++ b/src/main/java/org/helloworld/gymmate/dummy/controller/DummyDataController.java
@@ -41,4 +41,11 @@ public class DummyDataController {
         trainerDummyCreate.createTrainerDummy();
         return ResponseEntity.ok("트레이너 부가 정보 더미 데이터 생성 완료.");
     }
+
+    @Operation(summary = "owner의 gymId 업데이트")
+    @GetMapping("/trainer-gym")
+    public ResponseEntity<?> insertOwnerGym() {
+        dummyDataService.setGymForOwner();
+        return ResponseEntity.ok("트레이너의 gym정보 업데이트");
+    }
 }


### PR DESCRIPTION
# 📝 제목
refactor(dummy): 헬스장주인(트레이너)의 gym_id추가

---

## 🔘 Part
- dummy

---

## 🔎 작업 내용
- 헬스장 주인(trainer)의 gym_id를 추가하는 컨트롤러 추가
1) PartnerGym 테이블에서 전체 제휴 헬스장 정보를 조회
2) 조회한 각 PartnerGym에서 owner_id와 gymId를 Map에 저장한 뒤, 리스트로 변환
 3) batchUpdate를 통해 trainer 테이블의 gym_id를 일괄 업데이트

---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [x] 기존 기능 영향 없음
- [x] 실행 문제 없음
- [x] 테스트 완료 -> 포스트맨 테스트 완료(trainer_id의 gym_id만 따로 업데이트 가능)

---

## 🙏 리뷰 요청 사항


---

## 🔧 앞으로의 과제


---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
