### PR TITLE
refactor(partnergym) : 파트너짐 등록시 trainer에 gym 업데이트 + 기존 owner 파트너짐 데이터 기반 업데이트 쿼리

### DIFF
--- a/src/main/java/org/helloworld/gymmate/domain/user/trainer/entity/Trainer.java
+++ b/src/main/java/org/helloworld/gymmate/domain/user/trainer/entity/Trainer.java
@@ -160,4 +160,8 @@ public class Trainer {
         this.career = request.career();
         this.field = request.field();
     }
+
+    public void updateGym(Gym gym) {
+        this.gym = gym;
+    }
 }

--- a/src/main/resources/docs/update_trainer_gymid_by_partnergym.template
+++ b/src/main/resources/docs/update_trainer_gymid_by_partnergym.template
@@ -1,0 +1,6 @@
+USE gymmate_mysql;
+
+UPDATE gymmate_trainer t
+JOIN partner_gym p ON t.trainer_id = p.owner_id
+SET t.gym_id = p.gym_id
+WHERE t.is_owner = TRUE AND t.gym_id IS NULL;


### PR DESCRIPTION
# 📝 제목
feat(도메인): 내용 요약

---

## 🔘 Part
- 도메인

---

## 🔎 작업 내용
- 파트너짐 등록시 trainer에 gym 업데이트
- 기존 owner 파트너짐 데이터 기반 업데이트 쿼리

---

## 🖼️ 이미지 첨부
<img src="이미지 주소" width="50%" />

---

## 🔄 체크리스트
- [ ] 기존 기능 영향 없음
- [ ] 실행 문제 없음
- [ ] 테스트 완료

---

## 🙏 리뷰 요청 사항
- 지금 더미데이터에 trainer 중 is_owner는 1으로 트루인데, partnergym 엔티티가 없는 것들이 있음.
- 있는 trainer는 잘 업데이트 되는데 partnergym 엔티티가 없는 것들은 업데이트가 안됨

---

## 🔧 앞으로의 과제
- 이어서 해야 할 작업 or 미완료 사항 or 관련 추가 기능 등

---

## ➕ 이슈 링크
- #이슈번호 (자동 링크)

---
